### PR TITLE
Add support for loading config data from repo's release-manager.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ repositories:
   - id: C
 ```
 
-If a named repository wants to announce a dependency on another repo, the dependency needs to be listed in that repository's `.pipeline-config.yml`, simply by referring to its `repo.id` as defined in `metadata.yml`:
+If a named repository wants to announce a dependency on another repo, the dependency needs to be listed in that repository's `release-manager.yml`, simply by referring to its `repo.id` as defined in `metadata.yml`:
 
 ```
 dependencies:

--- a/test/org/ods/util/MROPipelineUtilSpec.groovy
+++ b/test/org/ods/util/MROPipelineUtilSpec.groovy
@@ -444,7 +444,7 @@ class MROPipelineUtilSpec extends SpecHelper {
         def repoDir = util.createDirectory(repoPath)
         def repos = createProject().repositories
 
-        def file = Paths.get(repoPath, MROPipelineUtil.PipelineConfig.FILE_NAME)
+        def file = Paths.get(repoPath, MROPipelineUtil.PipelineConfig.FILE_NAMES.first())
 
         when:
         file << """
@@ -524,7 +524,7 @@ class MROPipelineUtilSpec extends SpecHelper {
         def repoDir = util.createDirectory(repoPath)
         def repos = createProject().repositories
 
-        def file = Paths.get(repoPath, MROPipelineUtil.PipelineConfig.FILE_NAME)
+        def file = Paths.get(repoPath, MROPipelineUtil.PipelineConfig.FILE_NAMES.first())
 
         when:
         file << """
@@ -584,7 +584,7 @@ class MROPipelineUtilSpec extends SpecHelper {
         def repoDir = util.createDirectory(repoPath)
         def repos = createProject().repositories
 
-        def file = Paths.get(repoPath, MROPipelineUtil.PipelineConfig.FILE_NAME)
+        def file = Paths.get(repoPath, MROPipelineUtil.PipelineConfig.FILE_NAMES.first())
 
         when:
         file << """
@@ -626,7 +626,7 @@ class MROPipelineUtilSpec extends SpecHelper {
         def repoDir = util.createDirectory(repoPath)
         def repos = createProject().repositories
 
-        def file = Paths.get(repoPath, MROPipelineUtil.PipelineConfig.FILE_NAME)
+        def file = Paths.get(repoPath, MROPipelineUtil.PipelineConfig.FILE_NAMES.first())
 
         when:
         file << """
@@ -666,15 +666,15 @@ class MROPipelineUtilSpec extends SpecHelper {
 
         def repoPathA = Paths.get(steps.env.WORKSPACE, MROPipelineUtil.REPOS_BASE_DIR, "A").toString()
         def repoDirA = util.createDirectory(repoPathA)
-        def fileA = Paths.get(repoPathA, MROPipelineUtil.PipelineConfig.FILE_NAME)
+        def fileA = Paths.get(repoPathA, MROPipelineUtil.PipelineConfig.FILE_NAMES.first())
 
         def repoPathB = Paths.get(steps.env.WORKSPACE, MROPipelineUtil.REPOS_BASE_DIR, "B").toString()
         def repoDirB = util.createDirectory(repoPathB)
-        def fileB = Paths.get(repoPathB, MROPipelineUtil.PipelineConfig.FILE_NAME)
+        def fileB = Paths.get(repoPathB, MROPipelineUtil.PipelineConfig.FILE_NAMES.first())
 
         def repoPathC = Paths.get(steps.env.WORKSPACE, MROPipelineUtil.REPOS_BASE_DIR, "C").toString()
         def repoDirC = util.createDirectory(repoPathC)
-        def fileC = Paths.get(repoPathC, MROPipelineUtil.PipelineConfig.FILE_NAME)
+        def fileC = Paths.get(repoPathC, MROPipelineUtil.PipelineConfig.FILE_NAMES.first())
 
         def repos = createProject().repositories
 

--- a/vars/phaseInit.groovy
+++ b/vars/phaseInit.groovy
@@ -128,7 +128,7 @@ def call() {
         echo "Environment configuration: ${env.getEnvironment()}"
     })
 
-    // Load pipeline configs from each repo's .pipeline-config.yml
+    // Load configs from each repo's release-manager.yml
     util.loadPipelineConfigs(repos)
 
     // Compute groups of repository configs for convenient parallelization


### PR DESCRIPTION
For the moment, we keep support for `.pipeline-config.yml`, which is now up for future deprecation.

@michaelsauter We'll need to include this in the ODS2 release for consistency.

Closes #10.