### PR TITLE
Fix addressing of ODS components in Jira

### DIFF
--- a/src/org/ods/usecase/LeVADocumentUseCase.groovy
+++ b/src/org/ods/usecase/LeVADocumentUseCase.groovy
@@ -139,8 +139,8 @@ class LeVADocumentUseCase extends DocGenUseCase {
 
         if (!configurableItems.isEmpty()) {
             def configurableItemsIssuesList = configurableItems.collect { name, issues ->
-                // Remove the Technology_ prefix for ODS components
-                def matcher = name =~ /^Technology_/
+                // Remove the Technology- prefix for ODS components
+                def matcher = name =~ /^Technology-/
                 if (matcher.find()) {
                     name = matcher.replaceAll("")
                 }
@@ -226,12 +226,12 @@ class LeVADocumentUseCase extends DocGenUseCase {
             sections."sec3".specifications = SortUtil.sortIssuesByProperties(specificationsIssuesList, ["ur_key", "key"])
         }
 
-        // A mapping of component names starting with Technology_ to issues
-        def specificationsForTechnologyComponents = specifications.findAll { it.key.startsWith("Technology_") }
+        // A mapping of component names starting with Technology- to issues
+        def specificationsForTechnologyComponents = specifications.findAll { it.key.startsWith("Technology-") }
 
         // A mapping of component names to corresponding repository metadata
         def componentsMetadata = specificationsForTechnologyComponents.collectEntries { componentName, issues ->
-            def normalizedComponentName = componentName.replaceAll("Technology_", "")
+            def normalizedComponentName = componentName.replaceAll("Technology-", "")
 
             def repo = project.repositories.find { [it.id, it.name].contains(normalizedComponentName) }
             if (!repo) {
@@ -260,7 +260,7 @@ class LeVADocumentUseCase extends DocGenUseCase {
         }
 
         if (!specificationsForTechnologyComponents.isEmpty()) {
-            // Create a collection of disjoint issues across all components starting with Technology_
+            // Create a collection of disjoint issues across all components starting with Technology-
             def specificationsForTechnologyComponentsIssuesList = specificationsForTechnologyComponents.values().flatten().toSet()
 
             specificationsForTechnologyComponentsIssuesList = specificationsForTechnologyComponentsIssuesList.collect { issue ->
@@ -326,7 +326,7 @@ class LeVADocumentUseCase extends DocGenUseCase {
             sections = this.levaFiles.getDocumentChapterData(documentType)
         }
 
-        def jiraTestIssues = this.jira.getAutomatedTestIssues(project.id, "Technology_${repo.id}")
+        def jiraTestIssues = this.jira.getAutomatedTestIssues(project.id, "Technology-${repo.id}")
 
         def matchedHandler = { result ->
             result.each { issue, testcase ->
@@ -820,8 +820,8 @@ class LeVADocumentUseCase extends DocGenUseCase {
 
         if (!operational.isEmpty()) {
             def operationalIssuesList = operational.collect { name, epics ->
-                // Remove the Technology_ prefix for ODS components
-                def matcher = name =~ /^Technology_/
+                // Remove the Technology- prefix for ODS components
+                def matcher = name =~ /^Technology-/
                 if (matcher.find()) {
                     name = matcher.replaceAll("")
                 }

--- a/test/org/ods/usecase/LeVADocumentUseCaseSpec.groovy
+++ b/test/org/ods/usecase/LeVADocumentUseCaseSpec.groovy
@@ -299,7 +299,7 @@ class LeVADocumentUseCaseSpec extends SpecHelper {
         0 * levaFiles.getDocumentChapterData(documentType)
 
         then:
-        1 * jira.getAutomatedTestIssues(project.id, "Technology_${repo.id}") >> testIssues
+        1 * jira.getAutomatedTestIssues(project.id, "Technology-${repo.id}") >> testIssues
         1 * jira.matchJiraTestIssuesAgainstTestResults(testIssues, testResults, _, _)
         //1 * usecase.computeTestDiscrepancies("Development Tests", testIssues)
         1 * usecase.getDocumentMetadata(LeVADocumentUseCase.DOCUMENT_TYPE_NAMES[documentType], project, repo)
@@ -356,7 +356,7 @@ class LeVADocumentUseCaseSpec extends SpecHelper {
         1 * levaFiles.getDocumentChapterData(documentType) >> chapterData
 
         then:
-        1 * jira.getAutomatedTestIssues(project.id, "Technology_${repo.id}") >> testIssues
+        1 * jira.getAutomatedTestIssues(project.id, "Technology-${repo.id}") >> testIssues
         1 * jira.matchJiraTestIssuesAgainstTestResults(testIssues, testResults, _, _)
         //1 * usecase.computeTestDiscrepancies("Development Tests", testIssues)
         1 * usecase.getDocumentMetadata(LeVADocumentUseCase.DOCUMENT_TYPE_NAMES[documentType], project, repo)

--- a/vars/phaseBuild.groovy
+++ b/vars/phaseBuild.groovy
@@ -26,7 +26,7 @@ def call(Map project, List<Set<Map>> repos) {
             levaDocScheduler.run(phase, MROPipelineUtil.PipelinePhaseLifecycleStage.POST_EXECUTE_REPO, project, repo, data)
 
             // Report test results to corresponding test cases in Jira
-            jira.reportTestResultsForComponent(project.id, "Technology_${repo.id}", "UnitTest", data.testResults)
+            jira.reportTestResultsForComponent(project.id, "Technology-${repo.id}", "UnitTest", data.testResults)
         }
     }
 


### PR DESCRIPTION
Adjusts the prefix from `Technology_` to `Technology-`, so we properly address ODS components in Jira as created by the Provisioning App.