### PR TITLE
make ServiceRegistry typed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ build
 # IntelliJ
 .idea
 *.iws
+out

--- a/build.gradle
+++ b/build.gradle
@@ -92,7 +92,7 @@ dependencies {
 sourceSets {
     main {
         groovy {
-            srcDirs = ["src"]
+            srcDirs = ["src", "vars"]
         }
     }
 

--- a/src/org/ods/service/ServiceRegistry.groovy
+++ b/src/org/ods/service/ServiceRegistry.groovy
@@ -5,11 +5,11 @@ class ServiceRegistry {
 
     private registry = [:]
 
-    void add(def name, def service) {
-        registry[name] = service
+    void add(Class<?> type, def service) {
+        registry[type.name] = service
     }
 
-    def get(def name) {
-        return registry[name]
+    def <T> T get(Class<T> type) {
+        return registry[type.name] as T
     }
 }

--- a/test/groovy/org/ods/service/ServiceRegistrySpec.groovy
+++ b/test/groovy/org/ods/service/ServiceRegistrySpec.groovy
@@ -1,7 +1,5 @@
 package org.ods.service
 
-import spock.lang.*
-
 import util.*
 
 class ServiceRegistrySpec extends SpecHelper {
@@ -27,11 +25,11 @@ class ServiceRegistrySpec extends SpecHelper {
         def service = createService()
 
         when:
-        service.add("Service-A", new ServiceA())
-        service.add("Service-B", new ServiceB())
+        service.add(ServiceA, new ServiceA())
+        service.add(ServiceB, new ServiceB())
 
         then:
-        service.get("Service-A").run() == true
-        service.get("Service-B").run() == false
+        service.get(ServiceA).run()
+        !service.get(ServiceB).run()
     }
 }

--- a/vars/phaseBuild.groovy
+++ b/vars/phaseBuild.groovy
@@ -4,13 +4,12 @@ import org.ods.service.ServiceRegistry
 import org.ods.usecase.JUnitTestReportsUseCase
 import org.ods.usecase.JiraUseCase
 import org.ods.util.MROPipelineUtil
-import org.ods.util.PipelineUtil
 
 def call(Map project, List<Set<Map>> repos) {
-    def jira             = ServiceRegistry.instance.get(JiraUseCase.class.name)
-    def junit            = ServiceRegistry.instance.get(JUnitTestReportsUseCase.class.name)
-    def util             = ServiceRegistry.instance.get(PipelineUtil.class.name)
-    def levaDocScheduler = ServiceRegistry.instance.get(LeVADocumentScheduler.class.name)
+    def jira             = ServiceRegistry.instance.get(JiraUseCase)
+    def junit            = ServiceRegistry.instance.get(JUnitTestReportsUseCase)
+    def util             = ServiceRegistry.instance.get(MROPipelineUtil)
+    def levaDocScheduler = ServiceRegistry.instance.get(LeVADocumentScheduler)
 
     def phase = MROPipelineUtil.PipelinePhases.BUILD
 
@@ -64,8 +63,8 @@ def call(Map project, List<Set<Map>> repos) {
 }
 
 private List getUnitTestResults(def steps, Map repo) {
-    def jenkins = ServiceRegistry.instance.get(JenkinsService.class.name)
-    def junit   = ServiceRegistry.instance.get(JUnitTestReportsUseCase.class.name)
+    def jenkins = ServiceRegistry.instance.get(JenkinsService)
+    def junit   = ServiceRegistry.instance.get(JUnitTestReportsUseCase)
 
     def testReportsPath = "junit/${repo.id}/unit"
 

--- a/vars/phaseDeploy.groovy
+++ b/vars/phaseDeploy.groovy
@@ -1,11 +1,10 @@
 import org.ods.scheduler.LeVADocumentScheduler
 import org.ods.service.ServiceRegistry
 import org.ods.util.MROPipelineUtil
-import org.ods.util.PipelineUtil
 
 def call(Map project, List<Set<Map>> repos) {
-    def levaDocScheduler = ServiceRegistry.instance.get(LeVADocumentScheduler.class.name)
-    def util             = ServiceRegistry.instance.get(PipelineUtil.class.name)
+    def levaDocScheduler = ServiceRegistry.instance.get(LeVADocumentScheduler)
+    def util             = ServiceRegistry.instance.get(MROPipelineUtil)
 
     def phase = MROPipelineUtil.PipelinePhases.DEPLOY
 

--- a/vars/phaseFinalize.groovy
+++ b/vars/phaseFinalize.groovy
@@ -7,9 +7,9 @@ import org.ods.service.ServiceRegistry
 import org.ods.util.MROPipelineUtil
 
 def call(Map project, List<Set<Map>> repos) {
-    def levaDocScheduler = ServiceRegistry.instance.get(LeVADocumentScheduler.class.name)
-    def os               = ServiceRegistry.instance.get(OpenShiftService.class.name)
-    def util             = ServiceRegistry.instance.get(PipelineUtil.class.name)
+    def levaDocScheduler = ServiceRegistry.instance.get(LeVADocumentScheduler)
+    def os               = ServiceRegistry.instance.get(OpenShiftService)
+    def util             = ServiceRegistry.instance.get(MROPipelineUtil)
 
     def phase = MROPipelineUtil.PipelinePhases.FINALIZE
 

--- a/vars/phaseRelease.groovy
+++ b/vars/phaseRelease.groovy
@@ -1,11 +1,10 @@
 import org.ods.scheduler.LeVADocumentScheduler
 import org.ods.service.ServiceRegistry
 import org.ods.util.MROPipelineUtil
-import org.ods.util.PipelineUtil
 
 def call(Map project, List<Set<Map>> repos) {
-    def levaDocScheduler = ServiceRegistry.instance.get(LeVADocumentScheduler.class.name)
-    def util             = ServiceRegistry.instance.get(PipelineUtil.class.name)
+    def levaDocScheduler = ServiceRegistry.instance.get(LeVADocumentScheduler)
+    def util             = ServiceRegistry.instance.get(MROPipelineUtil)
 
     def phase = MROPipelineUtil.PipelinePhases.RELEASE
 

--- a/vars/phaseTest.groovy
+++ b/vars/phaseTest.groovy
@@ -4,15 +4,14 @@ import org.ods.service.ServiceRegistry
 import org.ods.usecase.JUnitTestReportsUseCase
 import org.ods.usecase.JiraUseCase
 import org.ods.util.MROPipelineUtil
-import org.ods.util.PipelineUtil
 
 import groovy.json.JsonOutput
 
 def call(Map project, List<Set<Map>> repos) {
-    def jira             = ServiceRegistry.instance.get(JiraUseCase.class.name)
-    def junit            = ServiceRegistry.instance.get(JUnitTestReportsUseCase.class.name)
-    def levaDocScheduler = ServiceRegistry.instance.get(LeVADocumentScheduler.class.name)
-    def util             = ServiceRegistry.instance.get(PipelineUtil.class.name)
+    def jira             = ServiceRegistry.instance.get(JiraUseCase)
+    def junit            = ServiceRegistry.instance.get(JUnitTestReportsUseCase)
+    def levaDocScheduler = ServiceRegistry.instance.get(LeVADocumentScheduler)
+    def util             = ServiceRegistry.instance.get(MROPipelineUtil)
 
     def phase = MROPipelineUtil.PipelinePhases.TEST
 
@@ -102,8 +101,8 @@ private List getIntegrationTestResults(def steps, Map repo) {
 }
 
 private List getTestResults(def steps, Map repo, String type) {
-    def jenkins = ServiceRegistry.instance.get(JenkinsService.class.name)
-    def junit   = ServiceRegistry.instance.get(JUnitTestReportsUseCase.class.name)
+    def jenkins = ServiceRegistry.instance.get(JenkinsService)
+    def junit   = ServiceRegistry.instance.get(JUnitTestReportsUseCase)
 
     def testReportsPath = "junit/${repo.id}/${type}"
 


### PR DESCRIPTION
this PR makes the ServiceRegistry typed so that the type of the returned instances can be inferred by your IDE / editor.
Also I added the vars folder as a source directory.
Both changes make it easier navigating the code in your IDE / editor and remove a little bit of boilerplate (".class.name" usage).