### PR TITLE
Fix repeated loading of project config

### DIFF
--- a/src/org/ods/util/MROPipelineUtil.groovy
+++ b/src/org/ods/util/MROPipelineUtil.groovy
@@ -316,9 +316,7 @@ class MROPipelineUtil extends PipelineUtil {
         return result
     }
 
-    Closure prepareCheckoutRepoNamedJob(Map repo, Closure preExecute = null, Closure postExecute = null) {
-        def project = loadProjectMetadata()
-
+    Closure prepareCheckoutRepoNamedJob(Map project, Map repo, Closure preExecute = null, Closure postExecute = null) {
         return [
             repo.id,
             {
@@ -356,7 +354,7 @@ class MROPipelineUtil extends PipelineUtil {
         ]
     }
 
-    void prepareCheckoutReposNamedJob(List<Map> repos, Closure preExecute = null, Closure postExecute = null) {
+    void prepareCheckoutReposNamedJob(Map project, List<Map> repos, Closure preExecute = null, Closure postExecute = null) {
         repos.collectEntries { repo ->
             prepareCheckoutRepoNamedJob(repo, preExecute, postExecute)
         }

--- a/src/org/ods/util/MROPipelineUtil.groovy
+++ b/src/org/ods/util/MROPipelineUtil.groovy
@@ -356,7 +356,7 @@ class MROPipelineUtil extends PipelineUtil {
 
     void prepareCheckoutReposNamedJob(Map project, List<Map> repos, Closure preExecute = null, Closure postExecute = null) {
         repos.collectEntries { repo ->
-            prepareCheckoutRepoNamedJob(repo, preExecute, postExecute)
+            this.prepareCheckoutRepoNamedJob(project, repo, preExecute, postExecute)
         }
     }
 

--- a/vars/phaseBuild.groovy
+++ b/vars/phaseBuild.groovy
@@ -4,6 +4,7 @@ import org.ods.service.ServiceRegistry
 import org.ods.usecase.JUnitTestReportsUseCase
 import org.ods.usecase.JiraUseCase
 import org.ods.util.MROPipelineUtil
+import org.ods.util.PipelineUtil
 
 def call(Map project, List<Set<Map>> repos) {
     def jira             = ServiceRegistry.instance.get(JiraUseCase)

--- a/vars/phaseInit.groovy
+++ b/vars/phaseInit.groovy
@@ -155,7 +155,7 @@ def call() {
     def phase = MROPipelineUtil.PipelinePhases.INIT
 
     // Checkout repositories into the workspace
-    parallel(util.prepareCheckoutReposNamedJob(repos) { steps_, repo ->
+    parallel(util.prepareCheckoutReposNamedJob(project, repos) { steps_, repo ->
         echo "Repository: ${repo}"
         echo "Environment configuration: ${env.getEnvironment()}"
     })

--- a/vars/phaseTest.groovy
+++ b/vars/phaseTest.groovy
@@ -1,5 +1,3 @@
-import groovy.json.JsonOutput
-
 import org.ods.scheduler.LeVADocumentScheduler
 import org.ods.service.JenkinsService
 import org.ods.service.ServiceRegistry

--- a/vars/phaseTest.groovy
+++ b/vars/phaseTest.groovy
@@ -1,11 +1,12 @@
+import groovy.json.JsonOutput
+
 import org.ods.scheduler.LeVADocumentScheduler
 import org.ods.service.JenkinsService
 import org.ods.service.ServiceRegistry
 import org.ods.usecase.JUnitTestReportsUseCase
 import org.ods.usecase.JiraUseCase
 import org.ods.util.MROPipelineUtil
-
-import groovy.json.JsonOutput
+import org.ods.util.PipelineUtil
 
 def call(Map project, List<Set<Map>> repos) {
     def jira             = ServiceRegistry.instance.get(JiraUseCase)


### PR DESCRIPTION
Currently, we load the project config once in `phaseInit`, and then again for each repository before the repository is checked out to address git credentials. This is unnecessary and leads to a clutter in the resulting Jenkins pipeline log.