### PR TITLE
provide a single entry point for the mro pipeline

### DIFF
--- a/vars/mroPipeline.groovy
+++ b/vars/mroPipeline.groovy
@@ -1,0 +1,44 @@
+def call(Map config) {
+
+    def project = [:]
+    def repos   = []
+
+    def debug = config.get('debug', false)
+
+    node {
+
+        checkout scm
+
+        withEnv (mroEnvironment(debug)) {
+
+            stage('Init') {
+                def result = phaseInit()
+                project = result.project
+                repos = result.repos
+            }
+
+            stage('Build') {
+                phaseBuild(project, repos)
+            }
+
+            stage('Deploy') {
+                phaseDeploy(project, repos)
+            }
+
+            stage('Test') {
+                phaseTest(project, repos)
+            }
+
+            stage('Release') {
+                phaseRelease(project, repos)
+            }
+
+            stage('Finalize') {
+                phaseFinalize(project, repos)
+            }
+        }
+    }
+
+}
+
+return this


### PR DESCRIPTION
Resolves #98

A release-manager `Jenkinsfile` could then use the new entry point like:

```
@Library(['ods-mro-jenkins-shared-library@production', 'ods-jenkins-shared-library@production']) _

def config = [debug: true]
mroPipeline(config)
```