### PR TITLE
Correct LeVA documents generated per GAMP category and its notification for each environment

### DIFF
--- a/src/org/ods/scheduler/LeVADocumentScheduler.groovy
+++ b/src/org/ods/scheduler/LeVADocumentScheduler.groovy
@@ -246,7 +246,7 @@ class LeVADocumentScheduler extends DocGenScheduler {
     }
 
     protected boolean isDocumentApplicable(String documentType, String phase, MROPipelineUtil.PipelinePhaseLifecycleStage stage, Map repo = null) {
-        if (!this.project.GAMPCategory) {
+        if (!this.project.hasCapability('LeVADocs')) {
             return false
         }
         def gampCategory = this.project.GAMPCategory

--- a/src/org/ods/scheduler/LeVADocumentScheduler.groovy
+++ b/src/org/ods/scheduler/LeVADocumentScheduler.groovy
@@ -10,64 +10,70 @@ class LeVADocumentScheduler extends DocGenScheduler {
     // Document types per GAMP category
     private static Map GAMP_CATEGORIES = [
         "1": [
-            LeVADocumentUseCase.DocumentType.SSDS as String,
             LeVADocumentUseCase.DocumentType.CSD as String,
             LeVADocumentUseCase.DocumentType.RA as String,
-            LeVADocumentUseCase.DocumentType.TRC as String,
-            LeVADocumentUseCase.DocumentType.CFTP as String,
-            LeVADocumentUseCase.DocumentType.CFTR as String,
-            LeVADocumentUseCase.DocumentType.IVP as String,
-            LeVADocumentUseCase.DocumentType.IVR as String,
-            LeVADocumentUseCase.DocumentType.TCP as String,
-            LeVADocumentUseCase.DocumentType.TCR as String,
+            LeVADocumentUseCase.DocumentType.SSDS as String,
             LeVADocumentUseCase.DocumentType.TIP as String,
             LeVADocumentUseCase.DocumentType.TIR as String,
-            LeVADocumentUseCase.DocumentType.OVERALL_TIR as String
+            LeVADocumentUseCase.DocumentType.OVERALL_TIR as String,
+            LeVADocumentUseCase.DocumentType.IVP as String,
+            LeVADocumentUseCase.DocumentType.IVR as String,
+            LeVADocumentUseCase.DocumentType.CFTP as String,
+            LeVADocumentUseCase.DocumentType.CFTR as String,
+            LeVADocumentUseCase.DocumentType.TCP as String,
+            LeVADocumentUseCase.DocumentType.TCR as String,
+            LeVADocumentUseCase.DocumentType.DIL as String,
         ],
         "3": [
-            LeVADocumentUseCase.DocumentType.SSDS as String,
-            LeVADocumentUseCase.DocumentType.RA as String,
-            LeVADocumentUseCase.DocumentType.IVP as String,
-            LeVADocumentUseCase.DocumentType.IVR as String,
             LeVADocumentUseCase.DocumentType.CSD as String,
-            LeVADocumentUseCase.DocumentType.TRC as String,
+            LeVADocumentUseCase.DocumentType.RA as String,
+            LeVADocumentUseCase.DocumentType.SSDS as String,
             LeVADocumentUseCase.DocumentType.TIP as String,
             LeVADocumentUseCase.DocumentType.TIR as String,
-            LeVADocumentUseCase.DocumentType.OVERALL_TIR as String
-        ],
-        "4": [
-            LeVADocumentUseCase.DocumentType.SSDS as String,
-            LeVADocumentUseCase.DocumentType.CSD as String,
-            LeVADocumentUseCase.DocumentType.RA as String,
-            LeVADocumentUseCase.DocumentType.TRC as String,
+            LeVADocumentUseCase.DocumentType.OVERALL_TIR as String,
+            LeVADocumentUseCase.DocumentType.IVP as String,
+            LeVADocumentUseCase.DocumentType.IVR as String,
             LeVADocumentUseCase.DocumentType.CFTP as String,
             LeVADocumentUseCase.DocumentType.CFTR as String,
+            LeVADocumentUseCase.DocumentType.TCP as String,
+            LeVADocumentUseCase.DocumentType.TCR as String,
+            LeVADocumentUseCase.DocumentType.DIL as String,
+            LeVADocumentUseCase.DocumentType.TRC as String,
+        ],
+        "4": [
+            LeVADocumentUseCase.DocumentType.CSD as String,
+            LeVADocumentUseCase.DocumentType.RA as String,
+            LeVADocumentUseCase.DocumentType.SSDS as String,
+            LeVADocumentUseCase.DocumentType.TIP as String,
+            LeVADocumentUseCase.DocumentType.TIR as String,
+            LeVADocumentUseCase.DocumentType.OVERALL_TIR as String,
             LeVADocumentUseCase.DocumentType.IVP as String,
             LeVADocumentUseCase.DocumentType.IVR as String,
             LeVADocumentUseCase.DocumentType.TCP as String,
             LeVADocumentUseCase.DocumentType.TCR as String,
-            LeVADocumentUseCase.DocumentType.TIP as String,
-            LeVADocumentUseCase.DocumentType.TIR as String,
-            LeVADocumentUseCase.DocumentType.OVERALL_TIR as String
+            LeVADocumentUseCase.DocumentType.CFTP as String,
+            LeVADocumentUseCase.DocumentType.CFTR as String,
+            LeVADocumentUseCase.DocumentType.DIL as String,
+            LeVADocumentUseCase.DocumentType.TRC as String,
         ],
         "5": [
             LeVADocumentUseCase.DocumentType.CSD as String,
-            LeVADocumentUseCase.DocumentType.TRC as String,
-            LeVADocumentUseCase.DocumentType.DIL as String,
-            LeVADocumentUseCase.DocumentType.DTP as String,
             LeVADocumentUseCase.DocumentType.RA as String,
+            LeVADocumentUseCase.DocumentType.SSDS as String,
+            LeVADocumentUseCase.DocumentType.DTP as String,
             LeVADocumentUseCase.DocumentType.DTR as String,
             LeVADocumentUseCase.DocumentType.OVERALL_DTR as String,
-            LeVADocumentUseCase.DocumentType.CFTP as String,
-            LeVADocumentUseCase.DocumentType.CFTR as String,
-            LeVADocumentUseCase.DocumentType.IVP as String,
-            LeVADocumentUseCase.DocumentType.IVR as String,
-            LeVADocumentUseCase.DocumentType.SSDS as String,
-            LeVADocumentUseCase.DocumentType.TCP as String,
-            LeVADocumentUseCase.DocumentType.TCR as String,
             LeVADocumentUseCase.DocumentType.TIP as String,
             LeVADocumentUseCase.DocumentType.TIR as String,
-            LeVADocumentUseCase.DocumentType.OVERALL_TIR as String
+            LeVADocumentUseCase.DocumentType.OVERALL_TIR as String,
+            LeVADocumentUseCase.DocumentType.IVP as String,
+            LeVADocumentUseCase.DocumentType.IVR as String,
+            LeVADocumentUseCase.DocumentType.CFTP as String,
+            LeVADocumentUseCase.DocumentType.CFTR as String,
+            LeVADocumentUseCase.DocumentType.TCP as String,
+            LeVADocumentUseCase.DocumentType.TCR as String,
+            LeVADocumentUseCase.DocumentType.DIL as String,
+            LeVADocumentUseCase.DocumentType.TRC as String,
         ]
     ]
 
@@ -130,29 +136,32 @@ class LeVADocumentScheduler extends DocGenScheduler {
     // Document types per environment token and label to track with Jira
     public static Map ENVIRONMENT_TYPE = [
         "D": [
-            (LeVADocumentUseCase.DocumentType.DTP as String)    : ["${LeVADocumentUseCase.DocumentType.DTP}"],
-            (LeVADocumentUseCase.DocumentType.CFTP as String)   : ["${LeVADocumentUseCase.DocumentType.CFTP}"],
-            (LeVADocumentUseCase.DocumentType.RA as String)     : ["${LeVADocumentUseCase.DocumentType.RA}"],
+            (LeVADocumentUseCase.DocumentType.CSD as String)    : ["${LeVADocumentUseCase.DocumentType.CSD}"],
             (LeVADocumentUseCase.DocumentType.SSDS as String)   : ["${LeVADocumentUseCase.DocumentType.SSDS}"],
-            (LeVADocumentUseCase.DocumentType.DIL as String)    : ["${LeVADocumentUseCase.DocumentType.DIL}_Q"],
-            (LeVADocumentUseCase.DocumentType.IVP as String)    : ["${LeVADocumentUseCase.DocumentType.IVP}_Q"],
-            (LeVADocumentUseCase.DocumentType.TIP as String)    : ["${LeVADocumentUseCase.DocumentType.TIP}_Q"],
-            (LeVADocumentUseCase.DocumentType.TCP as String)    : ["${LeVADocumentUseCase.DocumentType.TCP}"]
+            (LeVADocumentUseCase.DocumentType.RA as String)     : ["${LeVADocumentUseCase.DocumentType.RA}"],
+            (LeVADocumentUseCase.DocumentType.TIP as String)    : ["${LeVADocumentUseCase.DocumentType.TIP}_Q",
+                                                                    "${LeVADocumentUseCase.DocumentType.TIP}_P"],
+            (LeVADocumentUseCase.DocumentType.IVP as String)    : ["${LeVADocumentUseCase.DocumentType.IVP}_Q",
+                                                                    "${LeVADocumentUseCase.DocumentType.IVP}_P"],
+            (LeVADocumentUseCase.DocumentType.CFTP as String)   : ["${LeVADocumentUseCase.DocumentType.CFTP}_Q",
+                                                                    "${LeVADocumentUseCase.DocumentType.CFTP}_P"],
+            (LeVADocumentUseCase.DocumentType.TCP as String)    : ["${LeVADocumentUseCase.DocumentType.TCP}_Q",
+                                                                    "${LeVADocumentUseCase.DocumentType.TCP}_P"],
+            (LeVADocumentUseCase.DocumentType.DTP as String)    : ["${LeVADocumentUseCase.DocumentType.DTP}"],
         ],
         "Q": [
             (LeVADocumentUseCase.DocumentType.DTR as String)    : ["${LeVADocumentUseCase.DocumentType.DTR}"],
-            (LeVADocumentUseCase.DocumentType.CFTR as String)   : ["${LeVADocumentUseCase.DocumentType.CFTR}"],
-            (LeVADocumentUseCase.DocumentType.TRC as String)    : ["${LeVADocumentUseCase.DocumentType.TRC}"],
-            (LeVADocumentUseCase.DocumentType.DIL as String)    : ["${LeVADocumentUseCase.DocumentType.DIL}_P"],
-            (LeVADocumentUseCase.DocumentType.IVP as String)    : ["${LeVADocumentUseCase.DocumentType.IVP}_P"],
-            (LeVADocumentUseCase.DocumentType.IVR as String)    : ["${LeVADocumentUseCase.DocumentType.IVR}_Q"],
             (LeVADocumentUseCase.DocumentType.TIR as String)    : ["${LeVADocumentUseCase.DocumentType.TIR}_Q"],
+            (LeVADocumentUseCase.DocumentType.IVR as String)    : ["${LeVADocumentUseCase.DocumentType.IVR}_Q"],
+            (LeVADocumentUseCase.DocumentType.CFTR as String)   : ["${LeVADocumentUseCase.DocumentType.CFTR}"],
             (LeVADocumentUseCase.DocumentType.TCR as String)    : ["${LeVADocumentUseCase.DocumentType.TCR}"],
-            (LeVADocumentUseCase.DocumentType.TIP as String)    : ["${LeVADocumentUseCase.DocumentType.TIP}_P"]
+            (LeVADocumentUseCase.DocumentType.TRC as String)    : ["${LeVADocumentUseCase.DocumentType.TRC}"],
+            (LeVADocumentUseCase.DocumentType.DIL as String)    : ["${LeVADocumentUseCase.DocumentType.DIL}_Q"],
         ],
         "P": [
             (LeVADocumentUseCase.DocumentType.IVR as String)    : ["${LeVADocumentUseCase.DocumentType.IVR}_P"],
-            (LeVADocumentUseCase.DocumentType.TIR as String)    : ["${LeVADocumentUseCase.DocumentType.TIR}_P]"]
+            (LeVADocumentUseCase.DocumentType.TIR as String)    : ["${LeVADocumentUseCase.DocumentType.TIR}_P]"],
+            (LeVADocumentUseCase.DocumentType.DIL as String)    : ["${LeVADocumentUseCase.DocumentType.DIL}_P"]
         ]
     ]
 
@@ -237,16 +246,10 @@ class LeVADocumentScheduler extends DocGenScheduler {
     }
 
     protected boolean isDocumentApplicable(String documentType, String phase, MROPipelineUtil.PipelinePhaseLifecycleStage stage, Map repo = null) {
-        def levaDocsCapability = this.project.capabilities.find { it instanceof Map && it.containsKey("LeVADocs") }?.LeVADocs
-        if (!levaDocsCapability) {
+        if (!this.project.GAMPCategory) {
             return false
         }
-
-        def gampCategory = levaDocsCapability.GAMPCategory.toString()
-        if (!gampCategory) {
-            return false
-        }
-
+        def gampCategory = this.project.GAMPCategory
         return !repo
           ? isDocumentApplicableForProject(documentType, gampCategory, phase, stage)
           : isDocumentApplicableForRepo(documentType, gampCategory, phase, stage, repo)

--- a/src/org/ods/usecase/LeVADocumentUseCase.groovy
+++ b/src/org/ods/usecase/LeVADocumentUseCase.groovy
@@ -343,7 +343,8 @@ class LeVADocumentUseCase extends DocGenUseCase {
             }
         }
 
-        def uri = this.createDocument(documentType, null, data_, [:], null, null, watermarkText)
+        def documentTemplate = getDocumentTemplate(documentType)
+        def uri = this.createDocument(documentTemplate, null, data_, [:], null, documentType, watermarkText)
         this.notifyJiraTrackingIssue(documentType, "A new ${LeVADocumentUseCase.DOCUMENT_TYPE_NAMES[documentType]} has been generated and is available at: ${uri}.")
         return uri
     }
@@ -371,7 +372,8 @@ class LeVADocumentUseCase extends DocGenUseCase {
             ]
         ]
 
-        def uri = this.createDocument(documentType, null, data_, [:], null, null, watermarkText)
+        def documentTemplate = getDocumentTemplate(documentType)
+        def uri = this.createDocument(documentTemplate, null, data_, [:], null, documentType, watermarkText)
         this.notifyJiraTrackingIssue(documentType, "A new ${DOCUMENT_TYPE_NAMES[documentType]} has been generated and is available at: ${uri}.", sectionsNotDone)
         return uri
     }
@@ -474,7 +476,8 @@ class LeVADocumentUseCase extends DocGenUseCase {
             return document
         }
 
-        def uri = this.createDocument(documentType, repo, data_, files, modifier, null, watermarkText)
+        def documentTemplate = getDocumentTemplate(documentType)
+        def uri = this.createDocument(documentTemplate, repo, data_, files, modifier, documentType, watermarkText)
         this.notifyJiraTrackingIssue(documentType, "A new ${DOCUMENT_TYPE_NAMES[documentType]} has been generated and is available at: ${uri}.", sectionsNotDone)
         return uri
     }
@@ -582,7 +585,8 @@ class LeVADocumentUseCase extends DocGenUseCase {
             ]
         ]
 
-        def uri = this.createDocument(documentType, null, data_, [:], null, null, this.getWatermarkText(documentType, sectionsNotDone))
+        def documentTemplate = getDocumentTemplate(documentType)
+        def uri = this.createDocument(documentTemplate, null, data_, [:], null, documentType, this.getWatermarkText(documentType, sectionsNotDone))
         this.notifyJiraTrackingIssue(documentType, "A new ${DOCUMENT_TYPE_NAMES[documentType]} has been generated and is available at: ${uri}.", sectionsNotDone)
         return uri
     }
@@ -699,7 +703,8 @@ class LeVADocumentUseCase extends DocGenUseCase {
             ]
         ]
 
-        def uri = this.createDocument(documentType, null, data_, [:], null, null, watermarkText)
+        def documentTemplate = getDocumentTemplate(documentType)
+        def uri = this.createDocument(documentTemplate, null, data_, [:], null, documentType, watermarkText)
         this.notifyJiraTrackingIssue(documentType, "A new ${DOCUMENT_TYPE_NAMES[documentType]} has been generated and is available at: ${uri}.", sectionsNotDone)
         return uri
     }
@@ -786,7 +791,8 @@ class LeVADocumentUseCase extends DocGenUseCase {
             ]
         ]
 
-        def uri = this.createDocument(documentType, null, data_, [:], null, null, watermarkText)
+        def documentTemplate = getDocumentTemplate(documentType)
+        def uri = this.createDocument(documentTemplate, null, data_, [:], null, documentType, watermarkText)
         this.notifyJiraTrackingIssue(documentType, "A new ${DOCUMENT_TYPE_NAMES[documentType]} has been generated and is available at: ${uri}.", sectionsNotDone)
         return uri
     }
@@ -831,7 +837,8 @@ class LeVADocumentUseCase extends DocGenUseCase {
             ]
         ]
 
-        def uri = this.createDocument(documentType, null, data_, [:], null, null, watermarkText)
+        def documentTemplate = getDocumentTemplate(documentType)
+        def uri = this.createDocument(documentTemplate, null, data_, [:], null, documentType, watermarkText)
         this.notifyJiraTrackingIssue(documentType, "A new ${DOCUMENT_TYPE_NAMES[documentType]} has been generated and is available at: ${uri}.", sectionsNotDone)
         return uri
     }
@@ -899,7 +906,8 @@ class LeVADocumentUseCase extends DocGenUseCase {
             ["raw/${file.getName()}", file.getBytes()]
         }
 
-        def uri = this.createDocument(documentType, null, data_, files, null, null, watermarkText)
+        def documentTemplate = getDocumentTemplate(documentType)
+        def uri = this.createDocument(documentTemplate, null, data_, files, null, documentType, watermarkText)
         this.notifyJiraTrackingIssue(documentType, "A new ${DOCUMENT_TYPE_NAMES[documentType]} has been generated and is available at: ${uri}.", sectionsNotDone)
         return uri
     }
@@ -978,17 +986,10 @@ class LeVADocumentUseCase extends DocGenUseCase {
 
     String getDocumentTemplate(String documentType) {
         if (this.GAMP_CATEGORY_SENSITIVE_DOCS.contains(documentType)) {
-            documentType + "-" + obtainGampCategory()
+            documentType + "-" + this.project.GAMPCategory
         } else {
             documentType
         }
-    }
-
-    String obtainGampCategory() {
-        if (!this.project.GAMPCategory) {
-            throw new IllegalArgumentException("Error: Project is enabled for LeVADocs but contains no GAMPCategory.")
-        }
-        return this.project.GAMPCategory
     }
 
     String createTIP(Map repo = null, Map data = null) {
@@ -1012,7 +1013,8 @@ class LeVADocumentUseCase extends DocGenUseCase {
             ]
         ]
 
-        def uri = this.createDocument(documentType, null, data_, [:], null, null, watermarkText)
+        def documentTemplate = getDocumentTemplate(documentType)
+        def uri = this.createDocument(documentTemplate, null, data_, [:], null, documentType, watermarkText)
         this.notifyJiraTrackingIssue(documentType, "A new ${DOCUMENT_TYPE_NAMES[documentType]} has been generated and is available at: ${uri}.", sectionsNotDone)
         return uri
     }
@@ -1056,7 +1058,8 @@ class LeVADocumentUseCase extends DocGenUseCase {
             return document
         }
 
-        return this.createDocument(documentType, repo, data_, [:], modifier, null, watermarkText)
+        def documentTemplate = getDocumentTemplate(documentType)
+        return this.createDocument(documentTemplate, repo, data_, [:], modifier, documentType, watermarkText)
     }
 
     String createTRC(Map repo = null, Map data = null) {
@@ -1088,7 +1091,8 @@ class LeVADocumentUseCase extends DocGenUseCase {
             ]
         ]
 
-        def uri = this.createDocument(documentType, null, data_, [:], null, null, this.getWatermarkText(documentType, sectionsNotDone))
+        def documentTemplate = getDocumentTemplate(documentType)
+        def uri = this.createDocument(documentTemplate, null, data_, [:], null, documentType, this.getWatermarkText(documentType, sectionsNotDone))
         this.notifyJiraTrackingIssue(documentType, "A new ${DOCUMENT_TYPE_NAMES[documentType]} has been generated and is available at: ${uri}.", sectionsNotDone)
         return uri
     }

--- a/src/org/ods/util/Project.groovy
+++ b/src/org/ods/util/Project.groovy
@@ -1692,14 +1692,6 @@ class Project {
         return this.data.metadata.capabilities
     }
 
-    String getGAMPCategory() {
-        return this.data.metadata.GAMPCategory
-    }
-
-    void setGAMPCategory(String gampCategory) {
-        this.data.metadata.GAMPCategory = gampCategory
-    }
-
     List<JiraDataItem> getBugs() {
         return this.data.jira.bugs.values() as List
     }
@@ -1993,19 +1985,33 @@ class Project {
             result.capabilities = []
         }
 
-        // Check for GAMP category
+        // Check that LeVADocs capabilities in metadata.yml are well set-up
+        // TODO move me to the LeVA documents plugin
         def levaDocsCapability = result.capabilities.findAll { it instanceof Map && it.containsKey("LeVADocs") }
         if(levaDocsCapability) {
             if (levaDocsCapability.size() > 1) {
                 throw new IllegalArgumentException("Error: unable to parse project metadata. More than one LeVADocs items is defined in capabilities")
             }
-            def category = levaDocsCapability.first().LeVADocs.GAMPCategory
-            if (category) {
-                result.GAMPCategory = category.toString()
+            def category = levaDocsCapability.first().LeVADocs?.GAMPCategory
+            if (!category) {
+                throw new IllegalArgumentException("Error: Project is enabled for LeVADocs but contains no GAMPCategory.")
             }
+            result.GAMPCategory = category.toString()
         }
 
         return result
+    }
+
+	/**
+	 * Handy reference to easily get the GAMP category obtained through the LeVADocs Capability
+	 * TODO move me to the LeVA document plugin
+	 */
+    String getGAMPCategory() {
+        return this.data.metadata.GAMPCategory
+    }
+
+    void setGAMPCategory(String gampCategory) {
+        this.data.metadata.GAMPCategory = gampCategory
     }
 
     @NonCPS

--- a/src/org/ods/util/Project.groovy
+++ b/src/org/ods/util/Project.groovy
@@ -1692,6 +1692,14 @@ class Project {
         return this.data.metadata.capabilities
     }
 
+    String getGAMPCategory() {
+        return this.data.metadata.GAMPCategory
+    }
+
+    void setGAMPCategory(String gampCategory) {
+        this.data.metadata.GAMPCategory = gampCategory
+    }
+
     List<JiraDataItem> getBugs() {
         return this.data.jira.bugs.values() as List
     }
@@ -1984,6 +1992,19 @@ class Project {
         if (result.capabilities == null) {
             result.capabilities = []
         }
+
+        // Check for GAMP category
+        def levaDocsCapability = result.capabilities.findAll { it instanceof Map && it.containsKey("LeVADocs") }
+        if(levaDocsCapability) {
+            if (levaDocsCapability.size() > 1) {
+                throw new IllegalArgumentException("Error: unable to parse project metadata. More than one LeVADocs items is defined in capabilities")
+            }
+            def category = levaDocsCapability.first().LeVADocs.GAMPCategory
+            if (category) {
+                result.GAMPCategory = category.toString()
+            }
+        }
+
         return result
     }
 

--- a/test/groovy/org/ods/scheduler/LeVADocumentSchedulerSpec.groovy
+++ b/test/groovy/org/ods/scheduler/LeVADocumentSchedulerSpec.groovy
@@ -36,23 +36,29 @@ class LeVADocumentSchedulerSpec extends SpecHelper {
         REPO_ODS_TEST.type = MROPipelineUtil.PipelineConfig.REPO_TYPE_ODS_TEST
 
         PROJECT_GAMP_1 = createProject()
+        PROJECT_GAMP_1.capabilities << [ LeVADocs: [ GAMPCategory: "1" ] ]
         PROJECT_GAMP_1.GAMPCategory = "1"
 
         PROJECT_GAMP_3 = createProject()
+        PROJECT_GAMP_3.capabilities << [ LeVADocs: [ GAMPCategory: "3" ] ]
         PROJECT_GAMP_3.GAMPCategory = "3"
 
         PROJECT_GAMP_4 = createProject()
+        PROJECT_GAMP_4.capabilities << [ LeVADocs: [ GAMPCategory: "4" ] ]
         PROJECT_GAMP_4.GAMPCategory = "4"
 
         PROJECT_GAMP_5 = createProject()
+        PROJECT_GAMP_5.capabilities << [ LeVADocs: [ GAMPCategory: "5" ] ]
         PROJECT_GAMP_5.GAMPCategory = "5"
 
         PROJECT_GAMP_5_WITHOUT_JIRA = createProject()
-        PROJECT_GAMP_5.GAMPCategory = "5"
+        PROJECT_GAMP_5_WITHOUT_JIRA.capabilities << [ LeVADocs: [ GAMPCategory: "5" ] ]
+        PROJECT_GAMP_5_WITHOUT_JIRA.GAMPCategory = "5"
         PROJECT_GAMP_5_WITHOUT_JIRA.services.jira = null
 
         PROJECT_GAMP_5_WITHOUT_REPOS = createProject()
-        PROJECT_GAMP_5.GAMPCategory = "5"
+        PROJECT_GAMP_5_WITHOUT_REPOS.capabilities << [ LeVADocs: [ GAMPCategory: "5" ] ]
+        PROJECT_GAMP_5_WITHOUT_REPOS.GAMPCategory = "5"
         PROJECT_GAMP_5_WITHOUT_REPOS.repositories = []
     }
 
@@ -5667,6 +5673,7 @@ class LeVADocumentSchedulerSpec extends SpecHelper {
     def "is document applicable with invalid GAMP category"() {
         given:
         def project = createProject()
+        project.capabilities << [ LeVADocs: [ GAMPCategory: "0" ] ]
         project.GAMPCategory = "0"
 
         def steps = Spy(util.PipelineSteps)

--- a/test/groovy/org/ods/scheduler/LeVADocumentSchedulerSpec.groovy
+++ b/test/groovy/org/ods/scheduler/LeVADocumentSchedulerSpec.groovy
@@ -36,23 +36,23 @@ class LeVADocumentSchedulerSpec extends SpecHelper {
         REPO_ODS_TEST.type = MROPipelineUtil.PipelineConfig.REPO_TYPE_ODS_TEST
 
         PROJECT_GAMP_1 = createProject()
-        PROJECT_GAMP_1.capabilities << [ LeVADocs: [ GAMPCategory: "1" ] ]
+        PROJECT_GAMP_1.GAMPCategory = "1"
 
         PROJECT_GAMP_3 = createProject()
-        PROJECT_GAMP_3.capabilities << [ LeVADocs: [ GAMPCategory: "3" ] ]
+        PROJECT_GAMP_3.GAMPCategory = "3"
 
         PROJECT_GAMP_4 = createProject()
-        PROJECT_GAMP_4.capabilities << [ LeVADocs: [ GAMPCategory: "4" ] ]
+        PROJECT_GAMP_4.GAMPCategory = "4"
 
         PROJECT_GAMP_5 = createProject()
-        PROJECT_GAMP_5.capabilities << [ LeVADocs: [ GAMPCategory: "5" ] ]
+        PROJECT_GAMP_5.GAMPCategory = "5"
 
         PROJECT_GAMP_5_WITHOUT_JIRA = createProject()
-        PROJECT_GAMP_5_WITHOUT_JIRA.capabilities << [ LeVADocs: [ GAMPCategory: "5" ] ]
+        PROJECT_GAMP_5.GAMPCategory = "5"
         PROJECT_GAMP_5_WITHOUT_JIRA.services.jira = null
 
         PROJECT_GAMP_5_WITHOUT_REPOS = createProject()
-        PROJECT_GAMP_5_WITHOUT_REPOS.capabilities << [ LeVADocs: [ GAMPCategory: "5" ] ]
+        PROJECT_GAMP_5.GAMPCategory = "5"
         PROJECT_GAMP_5_WITHOUT_REPOS.repositories = []
     }
 
@@ -480,7 +480,7 @@ class LeVADocumentSchedulerSpec extends SpecHelper {
         LeVADocumentUseCase.DocumentType.TRC | null | MROPipelineUtil.PipelinePhases.DEPLOY   | MROPipelineUtil.PipelinePhaseLifecycleStage.PRE_EXECUTE_REPO  || false
         LeVADocumentUseCase.DocumentType.TRC | null | MROPipelineUtil.PipelinePhases.DEPLOY   | MROPipelineUtil.PipelinePhaseLifecycleStage.POST_EXECUTE_REPO || false
         LeVADocumentUseCase.DocumentType.TRC | null | MROPipelineUtil.PipelinePhases.DEPLOY   | MROPipelineUtil.PipelinePhaseLifecycleStage.PRE_END           || false
-        LeVADocumentUseCase.DocumentType.TRC | null | MROPipelineUtil.PipelinePhases.TEST     | MROPipelineUtil.PipelinePhaseLifecycleStage.POST_START        || true
+        LeVADocumentUseCase.DocumentType.TRC | null | MROPipelineUtil.PipelinePhases.TEST     | MROPipelineUtil.PipelinePhaseLifecycleStage.POST_START        || false
         LeVADocumentUseCase.DocumentType.TRC | null | MROPipelineUtil.PipelinePhases.TEST     | MROPipelineUtil.PipelinePhaseLifecycleStage.PRE_EXECUTE_REPO  || false
         LeVADocumentUseCase.DocumentType.TRC | null | MROPipelineUtil.PipelinePhases.TEST     | MROPipelineUtil.PipelinePhaseLifecycleStage.POST_EXECUTE_REPO || false
         LeVADocumentUseCase.DocumentType.TRC | null | MROPipelineUtil.PipelinePhases.TEST     | MROPipelineUtil.PipelinePhaseLifecycleStage.PRE_END           || false
@@ -1783,7 +1783,7 @@ class LeVADocumentSchedulerSpec extends SpecHelper {
         LeVADocumentUseCase.DocumentType.CFTP | null | MROPipelineUtil.PipelinePhases.DEPLOY   | MROPipelineUtil.PipelinePhaseLifecycleStage.PRE_EXECUTE_REPO  || false
         LeVADocumentUseCase.DocumentType.CFTP | null | MROPipelineUtil.PipelinePhases.DEPLOY   | MROPipelineUtil.PipelinePhaseLifecycleStage.POST_EXECUTE_REPO || false
         LeVADocumentUseCase.DocumentType.CFTP | null | MROPipelineUtil.PipelinePhases.DEPLOY   | MROPipelineUtil.PipelinePhaseLifecycleStage.PRE_END           || false
-        LeVADocumentUseCase.DocumentType.CFTP | null | MROPipelineUtil.PipelinePhases.TEST     | MROPipelineUtil.PipelinePhaseLifecycleStage.POST_START        || false
+        LeVADocumentUseCase.DocumentType.CFTP | null | MROPipelineUtil.PipelinePhases.TEST     | MROPipelineUtil.PipelinePhaseLifecycleStage.POST_START        || true
         LeVADocumentUseCase.DocumentType.CFTP | null | MROPipelineUtil.PipelinePhases.TEST     | MROPipelineUtil.PipelinePhaseLifecycleStage.PRE_EXECUTE_REPO  || false
         LeVADocumentUseCase.DocumentType.CFTP | null | MROPipelineUtil.PipelinePhases.TEST     | MROPipelineUtil.PipelinePhaseLifecycleStage.POST_EXECUTE_REPO || false
         LeVADocumentUseCase.DocumentType.CFTP | null | MROPipelineUtil.PipelinePhases.TEST     | MROPipelineUtil.PipelinePhaseLifecycleStage.PRE_END           || false
@@ -1984,7 +1984,7 @@ class LeVADocumentSchedulerSpec extends SpecHelper {
         LeVADocumentUseCase.DocumentType.CFTR | null | MROPipelineUtil.PipelinePhases.TEST     | MROPipelineUtil.PipelinePhaseLifecycleStage.POST_START        || false
         LeVADocumentUseCase.DocumentType.CFTR | null | MROPipelineUtil.PipelinePhases.TEST     | MROPipelineUtil.PipelinePhaseLifecycleStage.PRE_EXECUTE_REPO  || false
         LeVADocumentUseCase.DocumentType.CFTR | null | MROPipelineUtil.PipelinePhases.TEST     | MROPipelineUtil.PipelinePhaseLifecycleStage.POST_EXECUTE_REPO || false
-        LeVADocumentUseCase.DocumentType.CFTR | null | MROPipelineUtil.PipelinePhases.TEST     | MROPipelineUtil.PipelinePhaseLifecycleStage.PRE_END           || false
+        LeVADocumentUseCase.DocumentType.CFTR | null | MROPipelineUtil.PipelinePhases.TEST     | MROPipelineUtil.PipelinePhaseLifecycleStage.PRE_END           || true
         LeVADocumentUseCase.DocumentType.CFTR | null | MROPipelineUtil.PipelinePhases.RELEASE  | MROPipelineUtil.PipelinePhaseLifecycleStage.POST_START        || false
         LeVADocumentUseCase.DocumentType.CFTR | null | MROPipelineUtil.PipelinePhases.RELEASE  | MROPipelineUtil.PipelinePhaseLifecycleStage.PRE_EXECUTE_REPO  || false
         LeVADocumentUseCase.DocumentType.CFTR | null | MROPipelineUtil.PipelinePhases.RELEASE  | MROPipelineUtil.PipelinePhaseLifecycleStage.POST_EXECUTE_REPO || false
@@ -5667,7 +5667,7 @@ class LeVADocumentSchedulerSpec extends SpecHelper {
     def "is document applicable with invalid GAMP category"() {
         given:
         def project = createProject()
-        project.capabilities << [ LeVADocs: [ GAMPCategory: "0" ] ]
+        project.GAMPCategory = "0"
 
         def steps = Spy(util.PipelineSteps)
         def util = Mock(MROPipelineUtil)
@@ -5804,7 +5804,6 @@ class LeVADocumentSchedulerSpec extends SpecHelper {
         scheduler.run(MROPipelineUtil.PipelinePhases.TEST, MROPipelineUtil.PipelinePhaseLifecycleStage.POST_START)
 
         then:
-        1 * usecase.invokeMethod("createTRC", [null, null] as Object[])
         1 * usecase.invokeMethod("createCFTP", [null, null] as Object[])
         1 * usecase.invokeMethod("createIVP", [null, null] as Object[])
         1 * usecase.invokeMethod("createTCP", [null, null] as Object[])
@@ -5816,9 +5815,10 @@ class LeVADocumentSchedulerSpec extends SpecHelper {
         then:
         1 * usecase.invokeMethod("createCFTR", [[:], data] as Object[])
         1 * usecase.invokeMethod("createIVR", [[:], data] as Object[])
+        1 * usecase.invokeMethod("createTCR", [[:], data] as Object[])
         1 * usecase.invokeMethod("createRA", [[:], data] as Object[])
         1 * usecase.invokeMethod("createSSDS", [[:], data] as Object[])
-        1 * usecase.invokeMethod("createTCR", [[:], data] as Object[])
+        1 * usecase.invokeMethod("createDIL", [[:], data] as Object[])
         0 * usecase.invokeMethod(*_)
 
         when:
@@ -5881,7 +5881,9 @@ class LeVADocumentSchedulerSpec extends SpecHelper {
 
         then:
         1 * usecase.invokeMethod("createTRC", [null, null] as Object[])
+        1 * usecase.invokeMethod("createTCP", [null, null] as Object[])
         1 * usecase.invokeMethod("createIVP", [null, null] as Object[])
+        1 * usecase.invokeMethod("createCFTP", [null, null] as Object[])
         0 * usecase.invokeMethod(*_)
 
         when:
@@ -5890,6 +5892,9 @@ class LeVADocumentSchedulerSpec extends SpecHelper {
         then:
         1 * usecase.invokeMethod("createIVR", [[:], data] as Object[])
         1 * usecase.invokeMethod("createRA", [[:], data] as Object[])
+        1 * usecase.invokeMethod("createTCR", [[:], data] as Object[])
+        1 * usecase.invokeMethod("createDIL", [[:], data] as Object[])
+        1 * usecase.invokeMethod("createCFTR", [[:], data] as Object[])
         1 * usecase.invokeMethod("createSSDS", [[:], data] as Object[])
         0 * usecase.invokeMethod(*_)
     }
@@ -5964,6 +5969,7 @@ class LeVADocumentSchedulerSpec extends SpecHelper {
         1 * usecase.invokeMethod("createCFTR", [[:], data] as Object[])
         1 * usecase.invokeMethod("createIVR", [[:], data] as Object[])
         1 * usecase.invokeMethod("createRA", [[:], data] as Object[])
+        1 * usecase.invokeMethod("createDIL", [[:], data] as Object[])
         1 * usecase.invokeMethod("createSSDS", [[:], data] as Object[])
         1 * usecase.invokeMethod("createTCR", [[:], data] as Object[])
         0 * usecase.invokeMethod(*_)
@@ -6156,7 +6162,6 @@ class LeVADocumentSchedulerSpec extends SpecHelper {
         scheduler.run(MROPipelineUtil.PipelinePhases.DEPLOY, MROPipelineUtil.PipelinePhaseLifecycleStage.POST_START)
 
         then:
-        1 * usecase.invokeMethod("createTIP", [null, null] as Object[])
         0 * usecase.invokeMethod(*_)
 
         when:
@@ -6177,8 +6182,6 @@ class LeVADocumentSchedulerSpec extends SpecHelper {
         scheduler.run(MROPipelineUtil.PipelinePhases.TEST, MROPipelineUtil.PipelinePhaseLifecycleStage.POST_START)
 
         then:
-        1 * usecase.invokeMethod("createTRC", [null, null] as Object[])
-        1 * usecase.invokeMethod("createIVP", [null, null] as Object[])
         0 * usecase.invokeMethod(*_)
 
         when:
@@ -6187,6 +6190,7 @@ class LeVADocumentSchedulerSpec extends SpecHelper {
         then:
         1 * usecase.invokeMethod("createIVR", [[:], data] as Object[])
         1 * usecase.invokeMethod("createCFTR", [[:], data] as Object[])
+        1 * usecase.invokeMethod("createDIL", [[:], data] as Object[])
         1 * usecase.invokeMethod("createTCR", [[:], data] as Object[])
         0 * usecase.invokeMethod(*_)
     }
@@ -6236,7 +6240,6 @@ class LeVADocumentSchedulerSpec extends SpecHelper {
 
         then:
         1 * usecase.invokeMethod("createTRC", [null, null] as Object[])
-        1 * usecase.invokeMethod("createIVP", [null, null] as Object[])
         0 * usecase.invokeMethod(*_)
 
         when:
@@ -6244,6 +6247,9 @@ class LeVADocumentSchedulerSpec extends SpecHelper {
 
         then:
         1 * usecase.invokeMethod("createIVR", [[:], data] as Object[])
+        1 * usecase.invokeMethod("createDIL", [[:], data] as Object[])
+        1 * usecase.invokeMethod("createTCR", [[:], data] as Object[])
+        1 * usecase.invokeMethod("createCFTR", [[:], data] as Object[])
         0 * usecase.invokeMethod(*_)
     }
 
@@ -6292,7 +6298,6 @@ class LeVADocumentSchedulerSpec extends SpecHelper {
 
         then:
         1 * usecase.invokeMethod("createTRC", [null, null] as Object[])
-        1 * usecase.invokeMethod("createIVP", [null, null] as Object[])
         0 * usecase.invokeMethod(*_)
 
         when:
@@ -6300,6 +6305,7 @@ class LeVADocumentSchedulerSpec extends SpecHelper {
 
         then:
         1 * usecase.invokeMethod("createIVR", [[:], data] as Object[])
+        1 * usecase.invokeMethod("createDIL", [[:], data] as Object[])
         1 * usecase.invokeMethod("createCFTR", [[:], data] as Object[])
         1 * usecase.invokeMethod("createTCR", [[:], data] as Object[])
         0 * usecase.invokeMethod(*_)
@@ -6349,7 +6355,6 @@ class LeVADocumentSchedulerSpec extends SpecHelper {
         scheduler.run(MROPipelineUtil.PipelinePhases.DEPLOY, MROPipelineUtil.PipelinePhaseLifecycleStage.POST_START)
 
         then:
-        1 * usecase.invokeMethod("createTIP", [null, null] as Object[])
         0 * usecase.invokeMethod(*_)
 
         when:
@@ -6371,7 +6376,6 @@ class LeVADocumentSchedulerSpec extends SpecHelper {
 
         then:
         1 * usecase.invokeMethod("createTRC", [null, null] as Object[])
-        1 * usecase.invokeMethod("createIVP", [null, null] as Object[])
         0 * usecase.invokeMethod(*_)
 
         when:
@@ -6444,6 +6448,7 @@ class LeVADocumentSchedulerSpec extends SpecHelper {
 
         then:
         1 * usecase.invokeMethod("createIVR", [[:], data] as Object[])
+        1 * usecase.invokeMethod("createDIL", [[:], data] as Object[])
         0 * usecase.invokeMethod(*_)
     }
 
@@ -6539,6 +6544,7 @@ class LeVADocumentSchedulerSpec extends SpecHelper {
 
         then:
         1 * usecase.invokeMethod("createIVR", [[:], data] as Object[])
+        1 * usecase.invokeMethod("createDIL", [[:], data] as Object[])
         0 * usecase.invokeMethod(*_)
     }
 
@@ -6601,6 +6607,7 @@ class LeVADocumentSchedulerSpec extends SpecHelper {
 
         then:
         1 * usecase.invokeMethod("createIVR", [[:], data] as Object[])
+        1 * usecase.invokeMethod("createDIL", [[:], data] as Object[])
         0 * usecase.invokeMethod(*_)
     }
 
@@ -6679,11 +6686,12 @@ class LeVADocumentSchedulerSpec extends SpecHelper {
         // Test Parameters
         def qTypes = [
             LeVADocumentUseCase.DocumentType.DTR as String,
-            LeVADocumentUseCase.DocumentType.CFTR as String,
-            LeVADocumentUseCase.DocumentType.IVP as String,
-            LeVADocumentUseCase.DocumentType.IVR as String,
-            LeVADocumentUseCase.DocumentType.TIP as String,
             LeVADocumentUseCase.DocumentType.TIR as String,
+            LeVADocumentUseCase.DocumentType.IVR as String,
+            LeVADocumentUseCase.DocumentType.CFTR as String,
+            LeVADocumentUseCase.DocumentType.TCR as String,
+            LeVADocumentUseCase.DocumentType.TRC as String,
+            LeVADocumentUseCase.DocumentType.DIL as String,
         ]
 
         def result = []

--- a/test/groovy/org/ods/usecase/LeVADocumentUseCaseSpec.groovy
+++ b/test/groovy/org/ods/usecase/LeVADocumentUseCaseSpec.groovy
@@ -321,36 +321,6 @@ class LeVADocumentUseCaseSpec extends SpecHelper {
         result.conclusion.statement == "Some discrepancies found as tests did fail."
     }
 
-    def "obtain GAMP category"() {
-        given:
-        def categoryToTest = "999"
-        project.GAMPCategory = categoryToTest
-        jiraUseCase = Spy(new JiraUseCase(project, steps, util, Mock(JiraService)))
-        usecase = Spy(new LeVADocumentUseCase(project, steps, util, docGen, jenkins, jiraUseCase, junit, levaFiles, nexus, os, pdf, sq))
-
-        when:
-        def result = usecase.obtainGampCategory()
-
-        then:
-        result == categoryToTest as String
-
-    }
-
-    def "throw error if GAMP category is not set for project"() {
-        given:
-        when:
-        project.GAMPCategory = null
-        jiraUseCase = Spy(new JiraUseCase(project, steps, util, Mock(JiraService)))
-        usecase = Spy(new LeVADocumentUseCase(project, steps, util, docGen, jenkins, jiraUseCase, junit, levaFiles, nexus, os, pdf, sq))
-
-        then:
-        def msg = shouldFail IllegalArgumentException, {
-            usecase.obtainGampCategory()
-        }
-        msg.toString().contains("Error: Project is enabled for LeVADocs but contains no GAMPCategory")
-
-    }
-
     def "get correct templates for GAMP category sensitive documents"() {
         given:
         project.GAMPCategory = "999"
@@ -408,6 +378,7 @@ class LeVADocumentUseCaseSpec extends SpecHelper {
         // Stubbed Method Responses
         def chapterData = ["sec1": [content: "myContent", status: "DONE", key:"DEMO-1"]]
         def uri = "http://nexus"
+        def documentTemplate = "template"
 
         when:
         usecase.createTRC()
@@ -417,9 +388,10 @@ class LeVADocumentUseCaseSpec extends SpecHelper {
         0 * levaFiles.getDocumentChapterData(documentType)
 
         then:
+        1 * usecase.getDocumentTemplate(documentType) >> documentTemplate
         1 * project.getSystemRequirements()
         1 * usecase.getDocumentMetadata(LeVADocumentUseCase.DOCUMENT_TYPE_NAMES[documentType], _)
-        1 * usecase.createDocument(documentType, null, _, [:], _, null, _) >> uri
+        1 * usecase.createDocument(documentTemplate, null, _, [:], _, documentType, _) >> uri
         1 * usecase.notifyJiraTrackingIssue(documentType, "A new ${LeVADocumentUseCase.DOCUMENT_TYPE_NAMES[documentType]} has been generated and is available at: ${uri}.", [])
     }
 
@@ -431,6 +403,7 @@ class LeVADocumentUseCaseSpec extends SpecHelper {
         // Argument Constraints
         def documentType = LeVADocumentUseCase.DocumentType.DIL as String
         def uri = "http://nexus"
+        def documentTemplate = "template"
 
         when:
         usecase.createDIL()
@@ -439,9 +412,10 @@ class LeVADocumentUseCaseSpec extends SpecHelper {
         1 * usecase.getWatermarkText(documentType)
 
         then:
+        1 * usecase.getDocumentTemplate(documentType) >> documentTemplate
         1 * project.getBugs()
         1 * usecase.getDocumentMetadata(LeVADocumentUseCase.DOCUMENT_TYPE_NAMES[documentType])
-        1 * usecase.createDocument(documentType, null, _, [:], _, null, _) >> uri
+        1 * usecase.createDocument(documentTemplate, null, _, [:], _, documentType, _) >> uri
         1 * usecase.notifyJiraTrackingIssue(documentType, "A new ${LeVADocumentUseCase.DOCUMENT_TYPE_NAMES[documentType]} has been generated and is available at: ${uri}.")
     }
 
@@ -459,6 +433,7 @@ class LeVADocumentUseCaseSpec extends SpecHelper {
         // Stubbed Method Responses
         def chapterData = ["sec1": [content: "myContent", status: "DONE"]]
         def uri = "http://nexus"
+        def documentTemplate = "template"
 
         when:
         usecase.createDTP(repo)
@@ -469,9 +444,10 @@ class LeVADocumentUseCaseSpec extends SpecHelper {
         1 * usecase.getWatermarkText(documentType, [])
 
         then:
+        1 * usecase.getDocumentTemplate(documentType) >> documentTemplate
         1 * project.getAutomatedTestsTypeUnit()
         1 * usecase.getDocumentMetadata(LeVADocumentUseCase.DOCUMENT_TYPE_NAMES[documentType], repo)
-        1 * usecase.createDocument(documentType, null, _, [:], _, null, _) >> uri
+        1 * usecase.createDocument(documentTemplate, null, _, [:], _, documentType, _) >> uri
         1 * usecase.notifyJiraTrackingIssue(documentType, "A new ${LeVADocumentUseCase.DOCUMENT_TYPE_NAMES[documentType]} has been generated and is available at: ${uri}.", [])
     }
 
@@ -488,6 +464,7 @@ class LeVADocumentUseCaseSpec extends SpecHelper {
         // Stubbed Method Responses
         def chapterData = ["sec1": [content: "myContent", status: "DONE"]]
         def uri = "http://nexus"
+        def documentTemplate = "template"
 
         when:
         usecase.createDTP(repo)
@@ -498,9 +475,10 @@ class LeVADocumentUseCaseSpec extends SpecHelper {
         0 * usecase.getWatermarkText(documentType, [])
 
         then:
+        1 * usecase.getDocumentTemplate(documentType) >> documentTemplate
         1 * project.getAutomatedTestsTypeUnit()
         1 * usecase.getDocumentMetadata(LeVADocumentUseCase.DOCUMENT_TYPE_NAMES[documentType], repo)
-        1 * usecase.createDocument(documentType, null, _, [:], _, null, _) >> uri
+        1 * usecase.createDocument(documentTemplate, null, _, [:], _, documentType, _) >> uri
         1 * usecase.notifyJiraTrackingIssue(documentType, "A new ${LeVADocumentUseCase.DOCUMENT_TYPE_NAMES[documentType]} has been generated and is available at: ${uri}.", [])
     }
 
@@ -531,6 +509,7 @@ class LeVADocumentUseCaseSpec extends SpecHelper {
 
         // Stubbed Method Responses
         def chapterData = ["sec1": [content: "myContent", status: "DONE"]]
+        def documentTemplate = "template"
 
         when:
         usecase.createDTR(repo, data)
@@ -541,10 +520,11 @@ class LeVADocumentUseCaseSpec extends SpecHelper {
         1 * usecase.getWatermarkText(documentType, [])
 
         then:
+        1 * usecase.getDocumentTemplate(documentType) >> documentTemplate
         1 * project.getAutomatedTestsTypeUnit("Technology-${repo.id}")
         1 * usecase.computeTestDiscrepancies("Development Tests", testIssues, testResults)
         1 * usecase.getDocumentMetadata(LeVADocumentUseCase.DOCUMENT_TYPE_NAMES[documentType], repo)
-        1 * usecase.createDocument(documentType, repo, _, files, _, null, _)
+        1 * usecase.createDocument(documentTemplate, repo, _, files, _, documentType, _)
 
         cleanup:
         xmlFile.delete()
@@ -580,6 +560,7 @@ class LeVADocumentUseCaseSpec extends SpecHelper {
         // Stubbed Method Responses
         def buildParams = createProjectBuildEnvironment(env)
         def chapterData = ["sec1": [content: "myContent", status: "DONE"]]
+        def documentTemplate = "template"
 
         when:
         usecase.createDTR(repo, data)
@@ -590,10 +571,11 @@ class LeVADocumentUseCaseSpec extends SpecHelper {
         0 * usecase.getWatermarkText(documentType, [])
 
         then:
+        1 * usecase.getDocumentTemplate(documentType) >> documentTemplate
         1 * project.getAutomatedTestsTypeUnit("Technology-${repo.id}") >> testIssues
         1 * usecase.computeTestDiscrepancies("Development Tests", testIssues, testResults)
         1 * usecase.getDocumentMetadata(LeVADocumentUseCase.DOCUMENT_TYPE_NAMES[documentType], repo)
-        1 * usecase.createDocument(documentType, repo, _, files, _, null, _)
+        1 * usecase.createDocument(documentTemplate, repo, _, files, _, documentType, _)
     }
 
     def "create CFTP"() {
@@ -693,6 +675,7 @@ class LeVADocumentUseCaseSpec extends SpecHelper {
         // Stubbed Method Responses
         def chapterData = ["sec1": [content: "myContent", status: "DONE"]]
         def uri = "http://nexus"
+        def documentTemplate = "template"
 
         when:
         usecase.createTCP()
@@ -704,9 +687,10 @@ class LeVADocumentUseCaseSpec extends SpecHelper {
         then:
         1 * project.getAutomatedTestsTypeAcceptance()
         1 * project.getAutomatedTestsTypeIntegration()
+        1 * usecase.getDocumentTemplate(documentType) >> documentTemplate
         1 * usecase.getDocumentMetadata(LeVADocumentUseCase.DOCUMENT_TYPE_NAMES[documentType])
         1 * usecase.getWatermarkText(documentType, [])
-        1 * usecase.createDocument(documentType, null, _, [:], _, null, _) >> uri
+        1 * usecase.createDocument(documentTemplate, null, _, [:], _, documentType, _) >> uri
         1 * usecase.notifyJiraTrackingIssue(documentType, "A new ${LeVADocumentUseCase.DOCUMENT_TYPE_NAMES[documentType]} has been generated and is available at: ${uri}.", [])
     }
 
@@ -743,6 +727,7 @@ class LeVADocumentUseCaseSpec extends SpecHelper {
         // Stubbed Method Responses
         def chapterData = ["sec1": [content: "myContent", status: "DONE"]]
         def uri = "http://nexus"
+        def documentTemplate = "template"
 
         when:
         usecase.createTCR(null, data)
@@ -754,7 +739,8 @@ class LeVADocumentUseCaseSpec extends SpecHelper {
         then:
         1 * project.getAutomatedTestsTypeIntegration() >> integrationTestIssues
         1 * project.getAutomatedTestsTypeAcceptance() >> acceptanceTestIssues
-        1 * usecase.createDocument(documentType, null, _, [:], null, null, _) >> uri
+        1 * usecase.getDocumentTemplate(documentType) >> documentTemplate
+        1 * usecase.createDocument(documentTemplate, null, _, [:], null, documentType, _) >> uri
         1 * usecase.notifyJiraTrackingIssue(documentType, "A new ${LeVADocumentUseCase.DOCUMENT_TYPE_NAMES[documentType]} has been generated and is available at: ${uri}.", [])
         1 * usecase.getDocumentMetadata(LeVADocumentUseCase.DOCUMENT_TYPE_NAMES[documentType])
         1 * usecase.getWatermarkText(documentType, [])
@@ -776,6 +762,7 @@ class LeVADocumentUseCaseSpec extends SpecHelper {
         // Stubbed Method Responses
         def chapterData = ["sec1": [content: "myContent", status: "DONE"]]
         def uri = "http://nexus"
+        def documentTemplate = "template"
 
         when:
         usecase.createIVP()
@@ -788,7 +775,8 @@ class LeVADocumentUseCaseSpec extends SpecHelper {
         1 * project.getAutomatedTestsTypeInstallation()
         1 * usecase.getDocumentMetadata(LeVADocumentUseCase.DOCUMENT_TYPE_NAMES[documentType])
         1 * usecase.getWatermarkText(documentType, [])
-        1 * usecase.createDocument(documentType, null, _, [:], _, null, _) >> uri
+        1 * usecase.getDocumentTemplate(documentType) >> documentTemplate
+        1 * usecase.createDocument(documentTemplate, null, _, [:], _, documentType, _) >> uri
         1 * usecase.notifyJiraTrackingIssue(documentType, "A new ${LeVADocumentUseCase.DOCUMENT_TYPE_NAMES[documentType]} has been generated and is available at: ${uri}.", [])
     }
 
@@ -821,6 +809,7 @@ class LeVADocumentUseCaseSpec extends SpecHelper {
         // Stubbed Method Responses
         def chapterData = ["sec1": [content: "myContent", status: "DONE"]]
         def uri = "http://nexus"
+        def documentTemplate = "template"
 
         when:
         usecase.createIVR(null, data)
@@ -834,7 +823,8 @@ class LeVADocumentUseCaseSpec extends SpecHelper {
         1 * project.getAutomatedTestsTypeInstallation() >> testIssues
         1 * usecase.computeTestDiscrepancies("Installation Tests", testIssues, testResults)
         1 * usecase.getDocumentMetadata(LeVADocumentUseCase.DOCUMENT_TYPE_NAMES[documentType])
-        1 * usecase.createDocument(documentType, null, _, files, null, null, _) >> uri
+        1 * usecase.getDocumentTemplate(documentType) >> documentTemplate
+        1 * usecase.createDocument(documentTemplate, null, _, files, null, documentType, _) >> uri
         1 * usecase.notifyJiraTrackingIssue(documentType, "A new ${LeVADocumentUseCase.DOCUMENT_TYPE_NAMES[documentType]} has been generated and is available at: ${uri}.", [])
 
         cleanup:
@@ -913,6 +903,7 @@ class LeVADocumentUseCaseSpec extends SpecHelper {
         // Stubbed Method Responses
         def chapterData = ["sec1": [content: "myContent", status: "DONE"]]
         def uri = "http://nexus"
+        def documentTemplate = "template"
 
         when:
         usecase.createRA()
@@ -925,7 +916,8 @@ class LeVADocumentUseCaseSpec extends SpecHelper {
         2 * project.getRisks()
         1 * usecase.getDocumentMetadata(LeVADocumentUseCase.DOCUMENT_TYPE_NAMES[documentType], null)
         1 * usecase.getWatermarkText(documentType, [])
-        1 * usecase.createDocument(documentType, null, _, [:], _, null, _) >> uri
+        1 * usecase.getDocumentTemplate(documentType) >> documentTemplate
+        1 * usecase.createDocument(documentTemplate, null, _, [:], _, documentType, _) >> uri
         1 * usecase.notifyJiraTrackingIssue(documentType, "A new ${LeVADocumentUseCase.DOCUMENT_TYPE_NAMES[documentType]} has been generated and is available at: ${uri}.", [])
     }
 
@@ -940,6 +932,7 @@ class LeVADocumentUseCaseSpec extends SpecHelper {
         // Stubbed Method Responses
         def chapterData = ["sec1": [content: "myContent", status: "DONE"]]
         def uri = "http://nexus"
+        def documentTemplate = "template"
 
         when:
         usecase.createTIP()
@@ -951,7 +944,8 @@ class LeVADocumentUseCaseSpec extends SpecHelper {
 
         then:
         1 * usecase.getDocumentMetadata(LeVADocumentUseCase.DOCUMENT_TYPE_NAMES[documentType])
-        1 * usecase.createDocument(documentType, null, _, [:], _, null, _) >> uri
+        1 * usecase.getDocumentTemplate(documentType) >> documentTemplate
+        1 * usecase.createDocument(documentTemplate, null, _, [:], _, documentType, _) >> uri
         1 * usecase.notifyJiraTrackingIssue(documentType, "A new ${LeVADocumentUseCase.DOCUMENT_TYPE_NAMES[documentType]} has been generated and is available at: ${uri}.", [])
     }
 
@@ -965,6 +959,7 @@ class LeVADocumentUseCaseSpec extends SpecHelper {
         // Stubbed Method Responses
         def chapterData = ["sec1": [content: "myContent", status: "DONE"]]
         def uri = "http://nexus"
+        def documentTemplate = "template"
 
         when:
         usecase.createTIP()
@@ -976,7 +971,8 @@ class LeVADocumentUseCaseSpec extends SpecHelper {
 
         then:
         1 * usecase.getDocumentMetadata(LeVADocumentUseCase.DOCUMENT_TYPE_NAMES[documentType])
-        1 * usecase.createDocument(documentType, null, _, [:], _, null, _) >> uri
+        1 * usecase.getDocumentTemplate(documentType) >> documentTemplate
+        1 * usecase.createDocument(documentTemplate, null, _, [:], _, documentType, _) >> uri
         1 * usecase.notifyJiraTrackingIssue(documentType, "A new ${LeVADocumentUseCase.DOCUMENT_TYPE_NAMES[documentType]} has been generated and is available at: ${uri}.", [])
     }
 
@@ -990,6 +986,7 @@ class LeVADocumentUseCaseSpec extends SpecHelper {
 
         // Stubbed Method Responses
         def chapterData = ["sec1": [content: "myContent", status: "DONE"]]
+        def documentTemplate = "template"
 
         when:
         usecase.createTIR(repo)
@@ -1002,7 +999,8 @@ class LeVADocumentUseCaseSpec extends SpecHelper {
         then:
         1 * os.getPodDataForComponent(repo.id) >> createOpenShiftPodDataForComponent()
         1 * usecase.getDocumentMetadata(LeVADocumentUseCase.DOCUMENT_TYPE_NAMES[documentType], repo)
-        1 * usecase.createDocument(documentType, repo, _, [:], _, null, _)
+        1 * usecase.getDocumentTemplate(documentType) >> documentTemplate
+        1 * usecase.createDocument(documentTemplate, repo, _, [:], _, documentType, _)
     }
 
     def "create TIR without Jira"() {
@@ -1017,6 +1015,7 @@ class LeVADocumentUseCaseSpec extends SpecHelper {
 
         // Stubbed Method Responses
         def chapterData = ["sec1": [content: "myContent", status: "DONE"]]
+        def documentTemplate = "template"
 
         when:
         usecase.createTIR(repo)
@@ -1029,7 +1028,8 @@ class LeVADocumentUseCaseSpec extends SpecHelper {
         then:
         1 * os.getPodDataForComponent(repo.id) >> createOpenShiftPodDataForComponent()
         1 * usecase.getDocumentMetadata(LeVADocumentUseCase.DOCUMENT_TYPE_NAMES[documentType], repo)
-        1 * usecase.createDocument(documentType, repo, _, [:], _, null, _)
+        1 * usecase.getDocumentTemplate(documentType) >> documentTemplate
+        1 * usecase.createDocument(documentTemplate, repo, _, [:], _, documentType, _)
     }
 
     def "create overall DTR"() {
@@ -1049,7 +1049,7 @@ class LeVADocumentUseCaseSpec extends SpecHelper {
 
         then:
         1 * usecase.getDocumentMetadata(LeVADocumentUseCase.DOCUMENT_TYPE_NAMES[documentTypeName])
-        1 * usecase.createOverallDocument("Overall-Cover", documentType, _, null, _) >> uri
+        1 * usecase.createOverallDocument("Overall-Cover", documentType, _, _, _) >> uri
         1 * usecase.notifyJiraTrackingIssue(documentType, "A new ${LeVADocumentUseCase.DOCUMENT_TYPE_NAMES[documentTypeName]} has been generated and is available at: ${uri}.")
     }
 

--- a/test/groovy/org/ods/util/ProjectSpec.groovy
+++ b/test/groovy/org/ods/util/ProjectSpec.groovy
@@ -886,9 +886,9 @@ class ProjectSpec extends SpecHelper {
                 url: http://git.com
             capabilities:
               - LeVADocs:
-                GAMPCategory: 2
+                  GAMPCategory: 2
               - LeVADocs:
-                GAMPCategory: 3
+                  GAMPCategory: 3
         """
 
         project.loadMetadata()
@@ -915,6 +915,44 @@ class ProjectSpec extends SpecHelper {
         result.GAMPCategory == null
     }
 
+    def "fails when we have LeVADocs capabilities with no GAMPCategory " () {
+         when:
+         metadataFile.text = """
+            id: myId
+            name: myName
+            repositories:
+              - id: A
+                name: A
+                url: http://git.com
+            capabilities:
+              - LeVADocs:
+        """
+
+        def result = project.loadMetadata()
+
+        then:
+        def e = thrown(IllegalArgumentException)
+        e.message == "Error: Project is enabled for LeVADocs but contains no GAMPCategory."
+
+        when:
+         metadataFile.text = """
+            id: myId
+            name: myName
+            repositories:
+              - id: A
+                name: A
+                url: http://git.com
+            capabilities:
+              - LeVADocs:
+                GAMPCategory: 99
+        """
+
+        result = project.loadMetadata()
+
+        then:
+        e = thrown(IllegalArgumentException)
+        e.message == "Error: Project is enabled for LeVADocs but contains no GAMPCategory."
+    }
     def "sets-up GAMPCategory when loading project metadata" () {
          when:
          metadataFile.text = """

--- a/test/groovy/org/ods/util/ProjectSpec.groovy
+++ b/test/groovy/org/ods/util/ProjectSpec.groovy
@@ -874,4 +874,64 @@ class ProjectSpec extends SpecHelper {
         e = thrown(IllegalArgumentException)
         e.message == "Error: unable to parse project meta data. Required attribute 'repositories[1].id' is undefined."
     }
+
+    def "load project metadata with multiple LeVADocs in capabilities"() {
+        when:
+        metadataFile.text = """
+            id: myId
+            name: myName
+            repositories:
+              - id: A
+                name: A
+                url: http://git.com
+            capabilities:
+              - LeVADocs:
+                GAMPCategory: 2
+              - LeVADocs:
+                GAMPCategory: 3
+        """
+
+        project.loadMetadata()
+
+        then:
+        def e = thrown(IllegalArgumentException)
+        e.message == "Error: unable to parse project metadata. More than one LeVADocs items is defined in capabilities"
+    }
+
+    def "does not set-up GAMPCategory when loading project metadata if LeVADocs is not enabled" () {
+         when:
+         metadataFile.text = """
+            id: myId
+            name: myName
+            repositories:
+              - id: A
+                name: A
+                url: http://git.com
+        """
+
+        def result = project.loadMetadata()
+
+        then:
+        result.GAMPCategory == null
+    }
+
+    def "sets-up GAMPCategory when loading project metadata" () {
+         when:
+         metadataFile.text = """
+            id: myId
+            name: myName
+            repositories:
+              - id: A
+                name: A
+                url: http://git.com
+            capabilities:
+              - LeVADocs:
+                  GAMPCategory: 99
+        """
+
+        def result = project.loadMetadata()
+
+        then:
+        result.GAMPCategory == "99"
+    }
 }

--- a/test/groovy/util/FixtureHelper.groovy
+++ b/test/groovy/util/FixtureHelper.groovy
@@ -153,6 +153,15 @@ class FixtureHelper {
                     "LeVA_Doc:DIL_Q"
                 ]
             ],
+            "PLTFMDEV-1142": [
+                "key": "PLTFMDEV-1142",
+                "name": "Discrepancy Log for D",
+                "description": "C-DIL for D",
+                "status": "DONE",
+                "labels": [
+                    "LeVA_Doc:DIL"
+                ]
+            ],
             "PLTFMDEV-1013": [
                 "key"        : "PLTFMDEV-1013",
                 "name"       : "Combined Specification Document URS FS CS",
@@ -216,13 +225,22 @@ class FixtureHelper {
                     "LeVA_Doc:TC_CTR"
                 ]
             ],
-            "PLTFMDEV-426" : [
-                "key"        : "PLTFMDEV-426",
-                "name"       : "Test Case Plan",
-                "description": "TC-CTP",
-                "status"     : "DONE",
-                "labels"     : [
-                    "LeVA_Doc:TC_CTP"
+            "PLTFMDEV-1133": [
+                "key": "PLTFMDEV-1133",
+                "name": "Test Case Plan for P",
+                "description": "TCP_P",
+                "status": "DONE",
+                "labels": [
+                    "LeVA_Doc:TCP_P"
+                ]
+            ],
+            "PLTFMDEV-1132": [
+                "key": "PLTFMDEV-1132",
+                "name": "Test Case Plan for Q",
+                "description": "TCP_Q",
+                "status": "DONE",
+                "labels": [
+                    "LeVA_Doc:TCP_Q"
                 ]
             ],
             "PLTFMDEV-416" : [
@@ -324,6 +342,24 @@ class FixtureHelper {
                 "labels"     : [
                     "LeVA_Doc:CFTP",
                     "LeVA_Doc:FTP"
+                ]
+            ],
+            "PLTFMDEV-1129": [
+                "key": "PLTFMDEV-1129",
+                "name": "Combined Integration / Acceptance Testing Plan for P",
+                "description": "C-CFTP_P",
+                "status": "DONE",
+                "labels": [
+                    "LeVA_Doc:CFTP_P"
+                ]
+            ],
+            "PLTFMDEV-1128": [
+                "key": "PLTFMDEV-1128",
+                "name": "Combined Integration / Acceptance Testing Plan for Q",
+                "description": "C-CFTP_Q",
+                "status": "DONE",
+                "labels": [
+                    "LeVA_Doc:CFTP_Q"
                 ]
             ],
             "PLTFMDEV-15"  : [


### PR DESCRIPTION
For documents with GAMP category-variable content we have 1 template for each (e.g. SSDS-1, SSDS-3...). The document generated will not contain the GAMP category number in the artifact though. To avoid issues with document references in case the project changes overtime of category. 