### PR TITLE
Use correct label when querying pod and fix image imports

### DIFF
--- a/src/org/ods/service/OpenShiftService.groovy
+++ b/src/org/ods/service/OpenShiftService.groovy
@@ -253,13 +253,18 @@ class OpenShiftService {
       ''
     }
 
-    Map getPodDataForComponent(String name) {
-        String stdout = this.steps.sh(
-          script: "oc get pod -l component=${name} -o json --show-all=false",
-          returnStdout: true,
-          label: "Getting OpenShift Pod data for ${name}"
-        ).trim()
+    Map getPodDataForComponent(String deploymentName) {
+      String stdout = this.steps.sh(
+        script: "oc get pod -l deployment=${deploymentName} -o json",
+        returnStdout: true,
+        label: "Getting OpenShift pod data for ${deploymentName}"
+      ).trim()
 
-        return new JsonSlurperClassic().parseText(stdout)
+      def j = new JsonSlurperClassic().parseText(stdout)
+      if (j?.items[0]?.status?.phase?.toLowerCase() != 'running') {
+        throw new RuntimeException("Error: pod '${deploymentName}' is not running.")
+      }
+
+      return j.items[0]
     }
 }

--- a/src/org/ods/usecase/LeVADocumentUseCase.groovy
+++ b/src/org/ods/usecase/LeVADocumentUseCase.groovy
@@ -1021,7 +1021,9 @@ class LeVADocumentUseCase extends DocGenUseCase {
         }
         def sectionsNotDone = this.getSectionsNotDone(sections)
 
-        def pods = this.os.getPodDataForComponent(repo.id)
+        if (!data.pod) {
+            data.pod = os.getPodDataForComponent(data.odsBuildArtifacts?."OCP Deployment Id")
+        }
 
         def data_ = [
             metadata     : this.getDocumentMetadata(this.DOCUMENT_TYPE_NAMES[documentType], repo),
@@ -1029,13 +1031,13 @@ class LeVADocumentUseCase extends DocGenUseCase {
                 ocpBuildId          : data.odsBuildArtifacts?."OCP Build Id" ?: "N/A",
                 ocpDockerImage      : data.odsBuildArtifacts?."OCP Docker image" ?: "N/A",
                 ocpDeploymentId     : data.odsBuildArtifacts?."OCP Deployment Id" ?: "N/A",
-                podName             : data.pods.items[0].metadata?.name ?: "N/A",
-                podNamespace        : data.pods.items[0].metadata?.namespace ?: "N/A",
-                podCreationTimestamp: data.pods.items[0].metadata?.creationTimestamp ?: "N/A",
-                podEnvironment      : data.pods.items[0].metadata?.labels?.env ?: "N/A",
-                podNode             : data.pods.items[0].spec?.nodeName ?: "N/A",
-                podIp               : data.pods.items[0].status?.podIP ?: "N/A",
-                podStatus           : data.pods.items[0].status?.phase ?: "N/A"
+                podName             : data.pod.metadata?.name ?: "N/A",
+                podNamespace        : data.pod.metadata?.namespace ?: "N/A",
+                podCreationTimestamp: data.pod.metadata?.creationTimestamp ?: "N/A",
+                podEnvironment      : data.pod.metadata?.labels?.env ?: "N/A",
+                podNode             : data.pod.spec?.nodeName ?: "N/A",
+                podIp               : data.pod.status?.podIP ?: "N/A",
+                podStatus           : data.pod.status?.phase ?: "N/A"
             ],
             data         : [
                 repo    : repo,

--- a/src/org/ods/usecase/LeVADocumentUseCase.groovy
+++ b/src/org/ods/usecase/LeVADocumentUseCase.groovy
@@ -1031,13 +1031,13 @@ class LeVADocumentUseCase extends DocGenUseCase {
                 ocpBuildId          : data.odsBuildArtifacts?."OCP Build Id" ?: "N/A",
                 ocpDockerImage      : data.odsBuildArtifacts?."OCP Docker image" ?: "N/A",
                 ocpDeploymentId     : data.odsBuildArtifacts?."OCP Deployment Id" ?: "N/A",
-                podName             : data.pod.metadata?.name ?: "N/A",
-                podNamespace        : data.pod.metadata?.namespace ?: "N/A",
-                podCreationTimestamp: data.pod.metadata?.creationTimestamp ?: "N/A",
-                podEnvironment      : data.pod.metadata?.labels?.env ?: "N/A",
-                podNode             : data.pod.spec?.nodeName ?: "N/A",
-                podIp               : data.pod.status?.podIP ?: "N/A",
-                podStatus           : data.pod.status?.phase ?: "N/A"
+                podName             : data.pod?.metadata?.name ?: "N/A",
+                podNamespace        : data.pod?.metadata?.namespace ?: "N/A",
+                podCreationTimestamp: data.pod?.metadata?.creationTimestamp ?: "N/A",
+                podEnvironment      : data.pod?.metadata?.labels?.env ?: "N/A",
+                podNode             : data.pod?.spec?.nodeName ?: "N/A",
+                podIp               : data.pod?.status?.podIP ?: "N/A",
+                podStatus           : data.pod?.status?.phase ?: "N/A"
             ],
             data         : [
                 repo    : repo,

--- a/src/org/ods/usecase/LeVADocumentUseCase.groovy
+++ b/src/org/ods/usecase/LeVADocumentUseCase.groovy
@@ -1022,7 +1022,8 @@ class LeVADocumentUseCase extends DocGenUseCase {
         def sectionsNotDone = this.getSectionsNotDone(sections)
 
         if (!data.pod) {
-            data.pod = os.getPodDataForComponent(data.odsBuildArtifacts?."OCP Deployment Id")
+            this.steps.echo "Repo data 'pod' not populated, retrieving latest pod of component ${repo.id}..."
+            data.pod = os.getPodDataForComponent(this.project.key, repo.id)
         }
 
         def data_ = [

--- a/src/org/ods/util/MROPipelineUtil.groovy
+++ b/src/org/ods/util/MROPipelineUtil.groovy
@@ -187,7 +187,7 @@ class MROPipelineUtil extends PipelineUtil {
             }
 
             def definedImageSha = steps.readFile("${openshiftDir}/${imageShaFile}")
-            def sourceProject = "${this.project.key}-${this.project.concreteEnvironment}"
+            def sourceProject = "${this.project.key}-${Project.getConcreteEnvironment(this.project.sourceEnv, this.project.buildParams.version, this.project.versionedDevEnvsEnabled)}"
             if (this.project.targetClusterIsExternal) {
                 os.importImageFromSourceRegistry(
                     repo.id,

--- a/src/org/ods/util/MROPipelineUtil.groovy
+++ b/src/org/ods/util/MROPipelineUtil.groovy
@@ -222,7 +222,7 @@ class MROPipelineUtil extends PipelineUtil {
             }
 
             // collect data required for documents
-            def pod = os.getPodDataForComponent("${repo.id}-${latestVersion}")
+            def pod = os.getPodDataForDeployment(repo.id, latestVersion)
             repo.data.pod = pod
             repo.data.odsBuildArtifacts = [
                 "OCP Build Id": "N/A",

--- a/src/org/ods/util/MROPipelineUtil.groovy
+++ b/src/org/ods/util/MROPipelineUtil.groovy
@@ -222,14 +222,12 @@ class MROPipelineUtil extends PipelineUtil {
             }
 
             // collect data required for documents
-            def pods = os.getPodDataForComponent(repo.id)
-            repo.data['openshift'] = [
-                'pods': pods,
-                'odsBuildArtifacts': [
-                    "OCP Build Id": "N/A",
-                    "OCP Docker image": runningImageSha.split(':').last(),
-                    "OCP Deployment Id": latestVersion,
-                ]
+            def pod = os.getPodDataForComponent("${repo.id}-${latestVersion}")
+            repo.data.pod = pod
+            repo.data.odsBuildArtifacts = [
+                "OCP Build Id": "N/A",
+                "OCP Docker image": runningImageSha.split(':').last(),
+                "OCP Deployment Id": latestVersion,
             ]
 
             if (git.remoteTagExists(this.project.targetTag)) {

--- a/src/org/ods/util/Project.groovy
+++ b/src/org/ods/util/Project.groovy
@@ -425,8 +425,12 @@ class Project {
         this.data.git.targetTag
     }
 
+    boolean getVersionedDevEnvsEnabled() {
+        this.config.get('versionedDevEnvs', false)
+    }
+
     String getConcreteEnvironment() {
-        def versionedDevEnvs = this.config.get('versionedDevEnvs', false)
+        def versionedDevEnvs = getVersionedDevEnvsEnabled()
         getConcreteEnvironment(buildParams.targetEnvironment, buildParams.version, versionedDevEnvs)
     }
 

--- a/test/groovy/org/ods/usecase/LeVADocumentUseCaseSpec.groovy
+++ b/test/groovy/org/ods/usecase/LeVADocumentUseCaseSpec.groovy
@@ -1012,7 +1012,6 @@ class LeVADocumentUseCaseSpec extends SpecHelper {
         1 * usecase.getWatermarkText(documentType, [])
 
         then:
-        1 * os.getPodDataForComponent(repo.id) >> createOpenShiftPodDataForComponent()
         1 * usecase.getDocumentMetadata(LeVADocumentUseCase.DOCUMENT_TYPE_NAMES[documentType], repo)
         1 * usecase.getDocumentTemplateName(documentType) >> documentTemplate
         1 * usecase.createDocument(documentTemplate, repo, _, [:], _, documentType, _)
@@ -1052,7 +1051,6 @@ class LeVADocumentUseCaseSpec extends SpecHelper {
         1 * usecase.getWatermarkText(documentType, [])
 
         then:
-        1 * os.getPodDataForComponent(repo.id) >> createOpenShiftPodDataForComponent()
         1 * usecase.getDocumentMetadata(LeVADocumentUseCase.DOCUMENT_TYPE_NAMES[documentType], repo)
         1 * usecase.getDocumentTemplateName(documentType) >> documentTemplate
         1 * usecase.createDocument(documentTemplate, repo, _, [:], _, documentType, _)


### PR DESCRIPTION
src/org/ods/usecase/LeVADocumentUseCase.groovy#L1024 must have been a mistake when resolving merge conflicts - the return value is definitely not used.