### PR TITLE
WIP: several fixes around env promotion and doc mgmt

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,40 @@
+def odsImageTag = env.ODS_IMAGE_TAG ?: 'latest'
+def odsGitRef = env.ODS_GIT_REF ?: 'production'
+def final projectId = 'prov'
+def final componentId = 'jenkins-mro'
+def final credentialsId = "${projectId}-cd-cd-user-with-password"
+def dockerRegistry
+node {
+  dockerRegistry = env.DOCKER_REGISTRY
+}
+
+@Library('ods-jenkins-shared-library@${odsGitRef}') _
+
+// See readme of shared library for usage and customization.
+odsPipeline(
+  image: "${dockerRegistry}/cd/jenkins-slave-maven:${odsImageTag}",
+  projectId: projectId,
+  componentId: componentId,
+  branchToEnvironmentMapping: [
+    '*': 'dev'
+  ],
+  sonarQubeBranch: '*'
+) { context ->
+  stageBuild(context)
+  stageScanForSonarqube(context)
+}
+
+def stageBuild(def context) {
+  def javaOpts = "-Xmx512m"
+  def gradleTestOpts = "-Xmx128m"
+
+  stage('Unit Test') {
+    sh 'echo ${APP_DNS}'
+    withEnv(["TAGVERSION=${context.tagversion}", "NEXUS_USERNAME=${context.nexusUsername}", "NEXUS_PASSWORD=${context.nexusPassword}", "NEXUS_HOST=${context.nexusHost}", "JAVA_OPTS=${javaOpts}","GRADLE_TEST_OPTS=${gradleTestOpts}","ENVIRONMENT=${springBootEnv}"]) {
+      def status = sh(script: "./gradlew clean test jacocoTestReport --no-daemon --stacktrace", returnStatus: true)
+      if (status != 0) {
+        error "Build failed!"
+      }
+    }
+  }
+}

--- a/src/org/ods/scheduler/LeVADocumentScheduler.groovy
+++ b/src/org/ods/scheduler/LeVADocumentScheduler.groovy
@@ -199,7 +199,7 @@ class LeVADocumentScheduler extends DocGenScheduler {
         }
 
         // Applicable for certain document types only if the Jira service is configured in the release manager configuration
-        if ([LeVADocumentUseCase.DocumentType.CSD, LeVADocumentUseCase.DocumentType.SSDS].contains(documentType as LeVADocumentUseCase.DocumentType)) {
+        if ([LeVADocumentUseCase.DocumentType.CSD, LeVADocumentUseCase.DocumentType.SSDS, LeVADocumentUseCase.DocumentType.CFTP, LeVADocumentUseCase.DocumentType.CFTR,LeVADocumentUseCase.DocumentType.IVP,LeVADocumentUseCase.DocumentType.IVR,LeVADocumentUseCase.DocumentType.DIL].contains(documentType as LeVADocumentUseCase.DocumentType)) {
             result = result && this.project.services?.jira != null
         }
 

--- a/src/org/ods/scheduler/LeVADocumentScheduler.groovy
+++ b/src/org/ods/scheduler/LeVADocumentScheduler.groovy
@@ -199,7 +199,7 @@ class LeVADocumentScheduler extends DocGenScheduler {
         }
 
         // Applicable for certain document types only if the Jira service is configured in the release manager configuration
-        if ([LeVADocumentUseCase.DocumentType.CSD, LeVADocumentUseCase.DocumentType.SSDS, LeVADocumentUseCase.DocumentType.CFTP, LeVADocumentUseCase.DocumentType.CFTR,LeVADocumentUseCase.DocumentType.IVP,LeVADocumentUseCase.DocumentType.IVR,LeVADocumentUseCase.DocumentType.DIL].contains(documentType as LeVADocumentUseCase.DocumentType)) {
+        if ([LeVADocumentUseCase.DocumentType.CSD, LeVADocumentUseCase.DocumentType.SSDS, LeVADocumentUseCase.DocumentType.CFTP, LeVADocumentUseCase.DocumentType.CFTR,LeVADocumentUseCase.DocumentType.IVP,LeVADocumentUseCase.DocumentType.IVR,LeVADocumentUseCase.DocumentType.DIL, LeVADocumentUseCase.DocumentType.TCP, LeVADocumentUseCase.DocumentType.TCR, LeVADocumentUseCase.DocumentType.RA, LeVADocumentUseCase.DocumentType.TRC].contains(documentType as LeVADocumentUseCase.DocumentType)) {
             result = result && this.project.services?.jira != null
         }
 

--- a/src/org/ods/service/LeVADocumentChaptersFileService.groovy
+++ b/src/org/ods/service/LeVADocumentChaptersFileService.groovy
@@ -25,7 +25,7 @@ class LeVADocumentChaptersFileService {
         def String yamlText
         def file = Paths.get(this.steps.env.WORKSPACE, DOCUMENT_CHAPTERS_BASE_DIR, "${documentType}.yaml").toFile()
         if (!file.exists()) {
-            throw new RuntimeException("Error: unable to load document chapters. File '${file.toString()}' does not exist.")
+            this.steps.echo("Error: unable to load document chapters. File '${file.toString()}' does not exist.")
             yamlText = this.steps.readFile("docs/${documentType}.yaml")
         } else {
             yamlTest = file.text

--- a/src/org/ods/service/LeVADocumentChaptersFileService.groovy
+++ b/src/org/ods/service/LeVADocumentChaptersFileService.groovy
@@ -25,13 +25,10 @@ class LeVADocumentChaptersFileService {
         def String yamlText
         def file = Paths.get(this.steps.env.WORKSPACE, DOCUMENT_CHAPTERS_BASE_DIR, "${documentType}.yaml").toFile()
         if (!file.exists()) {
-            this.steps.echo("Error: unable to load document chapters. File '${file.toString()}' does not exist.")
             yamlText = this.steps.readFile("docs/${documentType}.yaml")
         } else {
             yamlText = file.text
         }
-        
-        this.steps.echo("template: ${yamlText}")
 
         def data = new Yaml().load(yamlText) ?: [:]
         return data.collectEntries { chapter ->

--- a/src/org/ods/service/LeVADocumentChaptersFileService.groovy
+++ b/src/org/ods/service/LeVADocumentChaptersFileService.groovy
@@ -24,8 +24,8 @@ class LeVADocumentChaptersFileService {
 
         def file = Paths.get(this.steps.env.WORKSPACE, DOCUMENT_CHAPTERS_BASE_DIR, "${documentType}.yaml").toFile()
         if (!file.exists()) {
-            this.steps.sh("find . -name ${documentType}.yaml")
             this.steps.sh("pwd")
+            this.steps.sh("ls -la ./docs/${documentType}.yaml")
             throw new RuntimeException("Error: unable to load document chapters. File '${file.toString()}' does not exist.")
         } else {
             this.steps.echo("Found file for ${documentType} @ '${file.toString()}'")

--- a/src/org/ods/service/LeVADocumentChaptersFileService.groovy
+++ b/src/org/ods/service/LeVADocumentChaptersFileService.groovy
@@ -25,6 +25,7 @@ class LeVADocumentChaptersFileService {
         def file = Paths.get(this.steps.env.WORKSPACE, DOCUMENT_CHAPTERS_BASE_DIR, "${documentType}.yaml").toFile()
         if (!file.exists()) {
             this.steps.sh("find . -name ${documentType}.yaml")
+            this.steps.sh("pwd")
             throw new RuntimeException("Error: unable to load document chapters. File '${file.toString()}' does not exist.")
         } else {
             this.steps.echo("Found file for ${documentType} @ '${file.toString()}'")

--- a/src/org/ods/service/LeVADocumentChaptersFileService.groovy
+++ b/src/org/ods/service/LeVADocumentChaptersFileService.groovy
@@ -28,10 +28,10 @@ class LeVADocumentChaptersFileService {
             this.steps.echo("Error: unable to load document chapters. File '${file.toString()}' does not exist.")
             yamlText = this.steps.readFile("docs/${documentType}.yaml")
         } else {
-            yamlTest = file.text
+            yamlText = file.text
         }
         
-        this.steps.echo("template: ${yamlTest}")
+        this.steps.echo("template: ${yamlText}")
 
         def data = new Yaml().load(yamlText) ?: [:]
         return data.collectEntries { chapter ->

--- a/src/org/ods/service/LeVADocumentChaptersFileService.groovy
+++ b/src/org/ods/service/LeVADocumentChaptersFileService.groovy
@@ -21,18 +21,19 @@ class LeVADocumentChaptersFileService {
         if (!documentType?.trim()) {
             throw new IllegalArgumentException("Error: unable to load document chapters. 'documentType' is undefined.")
         }
-        this.steps.sh("ls -la ./docs/${documentType}.yaml")
-        this.steps.sh("chmod 744 ./docs/${documentType}.yaml")
-        this.steps.sh("pwd")
-        this.steps.sh("find . -name ${documentType}.yaml")
+        
+        def String yamlText
         def file = Paths.get(this.steps.env.WORKSPACE, DOCUMENT_CHAPTERS_BASE_DIR, "${documentType}.yaml").toFile()
         if (!file.exists()) {
             throw new RuntimeException("Error: unable to load document chapters. File '${file.toString()}' does not exist.")
+            yamlText = this.steps.readFile("docs/${documentType}.yaml")
         } else {
-            this.steps.echo("Found file for ${documentType} @ '${file.toString()}'")
+            yamlTest = file.text
         }
+        
+        this.steps.echo("template: ${yamlTest}")
 
-        def data = new Yaml().load(file.text) ?: [:]
+        def data = new Yaml().load(yamlText) ?: [:]
         return data.collectEntries { chapter ->
             def number = chapter.number.toString()
             chapter.number = number

--- a/src/org/ods/service/LeVADocumentChaptersFileService.groovy
+++ b/src/org/ods/service/LeVADocumentChaptersFileService.groovy
@@ -23,6 +23,8 @@ class LeVADocumentChaptersFileService {
         }
         this.steps.sh("ls -la ./docs/${documentType}.yaml")
         this.steps.sh("chmod 744 ./docs/${documentType}.yaml")
+        this.steps.sh("pwd")
+        this.steps.sh("find . -name ${documentType}.yaml")
         def file = Paths.get(this.steps.env.WORKSPACE, DOCUMENT_CHAPTERS_BASE_DIR, "${documentType}.yaml").toFile()
         if (!file.exists()) {
             throw new RuntimeException("Error: unable to load document chapters. File '${file.toString()}' does not exist.")

--- a/src/org/ods/service/LeVADocumentChaptersFileService.groovy
+++ b/src/org/ods/service/LeVADocumentChaptersFileService.groovy
@@ -24,7 +24,10 @@ class LeVADocumentChaptersFileService {
 
         def file = Paths.get(this.steps.env.WORKSPACE, DOCUMENT_CHAPTERS_BASE_DIR, "${documentType}.yaml").toFile()
         if (!file.exists()) {
+            this.steps.sh("find . -name ${documentType}.yaml")
             throw new RuntimeException("Error: unable to load document chapters. File '${file.toString()}' does not exist.")
+        } else {
+            this.steps.echo("Found file for ${documentType} @ '${file.toString()}'")
         }
 
         def data = new Yaml().load(file.text) ?: [:]

--- a/src/org/ods/service/LeVADocumentChaptersFileService.groovy
+++ b/src/org/ods/service/LeVADocumentChaptersFileService.groovy
@@ -21,11 +21,10 @@ class LeVADocumentChaptersFileService {
         if (!documentType?.trim()) {
             throw new IllegalArgumentException("Error: unable to load document chapters. 'documentType' is undefined.")
         }
-
+        this.steps.sh("ls -la ./docs/${documentType}.yaml")
+        this.steps.sh("chmod 744 ./docs/${documentType}.yaml")
         def file = Paths.get(this.steps.env.WORKSPACE, DOCUMENT_CHAPTERS_BASE_DIR, "${documentType}.yaml").toFile()
         if (!file.exists()) {
-            this.steps.sh("pwd")
-            this.steps.sh("ls -la ./docs/${documentType}.yaml")
             throw new RuntimeException("Error: unable to load document chapters. File '${file.toString()}' does not exist.")
         } else {
             this.steps.echo("Found file for ${documentType} @ '${file.toString()}'")

--- a/src/org/ods/service/OpenShiftService.groovy
+++ b/src/org/ods/service/OpenShiftService.groovy
@@ -303,8 +303,8 @@ class OpenShiftService {
         pod.podCreationTimestamp = podOCData?.metadata?.creationTimestamp?: "N/A"
         pod.podEnvironment = podOCData?.metadata?.labels?.env?: "N/A"
         pod.podNode = podOCData?.spec?.nodeName ?: "N/A"
-        pod.podNode = podOCData?.status?.podIP ?: "N/A"
-        pod.podNode = podOCData?.status?.phase ?: "N/A"
+        pod.podIp = podOCData?.status?.podIP ?: "N/A"
+        pod.podStatus = podOCData?.status?.phase ?: "N/A"
       
       return pod
     }

--- a/src/org/ods/service/OpenShiftService.groovy
+++ b/src/org/ods/service/OpenShiftService.groovy
@@ -293,8 +293,22 @@ class OpenShiftService {
       if (j?.items[0]?.status?.phase?.toLowerCase() != 'running') {
         throw new RuntimeException("Error: no pod for ${description} running / found.")
       }
-
-      return j.items[0]
+      
+      def podOCData = j.items[0]
+      
+      // strip all data not needed out
+      def pod = [ : ]
+        pod.podName = podOCData?.metadata?.name?: "N/A"
+        pod.podNamespace = podOCData?.metadata?.namespace?: "N/A"
+        pod.podCreationTimestamp = podOCData?.metadata?.creationTimestamp?: "N/A"
+        pod.podEnvironment = podOCData?.metadata?.labels?.env?: "N/A"
+        pod.podNode = podOCData?.spec?.nodeName ?: "N/A"
+        pod.podNode = podOCData?.status?.podIP ?: "N/A"
+        pod.podNode = podOCData?.status?.phase ?: "N/A"
+      
+      this.steps.echo("Pod: ${description} ${pod}")
+      
+      return pod
     }
 
 }

--- a/src/org/ods/service/OpenShiftService.groovy
+++ b/src/org/ods/service/OpenShiftService.groovy
@@ -291,7 +291,13 @@ class OpenShiftService {
     private Map extractPodData(String ocOutput, String description) {
       def j = new JsonSlurperClassic().parseText(ocOutput)
       if (j?.items[0]?.status?.phase?.toLowerCase() != 'running') {
-        throw new RuntimeException("Error: no pod for ${description} running / found.")
+        def currentProject = this.steps.sh(
+          script: "oc project | cut -d \" \" -f3",
+          returnStdout: true,
+          label: "Getting OC project"
+        ).trim()
+        
+        throw new RuntimeException("Error: no pod for ${description} running / found in project ${currentProject}")
       }
       
       def podOCData = j.items[0]

--- a/src/org/ods/service/OpenShiftService.groovy
+++ b/src/org/ods/service/OpenShiftService.groovy
@@ -306,8 +306,6 @@ class OpenShiftService {
         pod.podNode = podOCData?.status?.podIP ?: "N/A"
         pod.podNode = podOCData?.status?.phase ?: "N/A"
       
-      this.steps.echo("Pod: ${description} ${pod}")
-      
       return pod
     }
 

--- a/src/org/ods/usecase/DocGenUseCase.groovy
+++ b/src/org/ods/usecase/DocGenUseCase.groovy
@@ -44,7 +44,7 @@ abstract class DocGenUseCase {
         def basename = this.getDocumentBasename(documentTypeEmbedded ?: documentType, this.project.buildParams.version, this.steps.env.BUILD_ID, repo)
 
         // Create an archive with the document and raw data
-        def byte[] archive = this.util.createZipArtifact(
+        def archive = this.util.createZipArtifact(
             "${basename}.zip",
             [
                 "${basename}.pdf": document,

--- a/src/org/ods/usecase/DocGenUseCase.groovy
+++ b/src/org/ods/usecase/DocGenUseCase.groovy
@@ -63,6 +63,7 @@ abstract class DocGenUseCase {
             "application/zip"
         )
 
+        this.steps.echo ("Document ${documentType} for ${repo.id} uploaded @ ${uri.toString()}")
         return uri.toString()
     }
 

--- a/src/org/ods/usecase/DocGenUseCase.groovy
+++ b/src/org/ods/usecase/DocGenUseCase.groovy
@@ -44,7 +44,7 @@ abstract class DocGenUseCase {
         def basename = this.getDocumentBasename(documentTypeEmbedded ?: documentType, this.project.buildParams.version, this.steps.env.BUILD_ID, repo)
 
         // Create an archive with the document and raw data
-        def archive = this.util.createZipArtifact(
+        def byte[] archive = this.util.createZipArtifact(
             "${basename}.zip",
             [
                 "${basename}.pdf": document,

--- a/src/org/ods/usecase/LeVADocumentUseCase.groovy
+++ b/src/org/ods/usecase/LeVADocumentUseCase.groovy
@@ -77,6 +77,10 @@ class LeVADocumentUseCase extends DocGenUseCase {
         this.levaFiles = levaFiles
         this.os = os
         this.sq = sq
+        
+        if (!project.getCapability('LeVADocs')) {
+          steps.echo("----- Attention: NO documents will be generated, as no Capability is defined -----")
+        }
     }
 
     /**

--- a/src/org/ods/usecase/LeVADocumentUseCase.groovy
+++ b/src/org/ods/usecase/LeVADocumentUseCase.groovy
@@ -1032,7 +1032,7 @@ class LeVADocumentUseCase extends DocGenUseCase {
         def sectionsNotDone = this.getSectionsNotDone(sections)
         def watermarkText = this.getWatermarkText(documentType, sectionsNotDone)
 
-        if (!data.openshift.pod) {
+        if (!data.openshift?.pod) {
             this.steps.echo "Repo data 'pod' not populated, retrieving latest pod of component ${repo.id}..."
             data.openshift.pod = os.getPodDataForComponent(this.project.key, repo.id)
         }

--- a/src/org/ods/usecase/LeVADocumentUseCase.groovy
+++ b/src/org/ods/usecase/LeVADocumentUseCase.groovy
@@ -1245,7 +1245,7 @@ class LeVADocumentUseCase extends DocGenUseCase {
 
     protected List<Map> getSectionsNotDone (Map issues = [:]) {
         if (!issues) return []
-        return issues.values().findAll { !it.status.equalsIgnoreCase("done") }
+        return issues.values().findAll { !it.status?.equalsIgnoreCase("done") }
     }
 
     String getDocumentTemplatesVersion() {

--- a/src/org/ods/usecase/LeVADocumentUseCase.groovy
+++ b/src/org/ods/usecase/LeVADocumentUseCase.groovy
@@ -1034,9 +1034,11 @@ class LeVADocumentUseCase extends DocGenUseCase {
 
         if (!data.openshift?.pod) {
             this.steps.echo "Repo data 'pod' not populated, retrieving latest pod of component ${repo.id}..."
-            data.openshift.pod = os.getPodDataForComponent(this.project.key, repo.id) 
+            data.openshift = ['pod' : os.getPodDataForComponent(this.project.key, repo.id)]
         }
 
+        this.steps.echo("Pod: ${description} ${pod}")
+        
         def data_ = [
             metadata     : this.getDocumentMetadata(this.DOCUMENT_TYPE_NAMES[documentType], repo),
             openShiftData: [

--- a/src/org/ods/usecase/LeVADocumentUseCase.groovy
+++ b/src/org/ods/usecase/LeVADocumentUseCase.groovy
@@ -1032,24 +1032,24 @@ class LeVADocumentUseCase extends DocGenUseCase {
         def sectionsNotDone = this.getSectionsNotDone(sections)
         def watermarkText = this.getWatermarkText(documentType, sectionsNotDone)
 
-        if (!data.pod) {
+        if (!data.openshift.pod) {
             this.steps.echo "Repo data 'pod' not populated, retrieving latest pod of component ${repo.id}..."
-            data.pod = os.getPodDataForComponent(this.project.key, repo.id)
+            data.openshift.pod = os.getPodDataForComponent(this.project.key, repo.id)
         }
 
         def data_ = [
             metadata     : this.getDocumentMetadata(this.DOCUMENT_TYPE_NAMES[documentType], repo),
             openShiftData: [
-                ocpBuildId          : data.odsBuildArtifacts?."OCP Build Id" ?: "N/A",
-                ocpDockerImage      : data.odsBuildArtifacts?."OCP Docker image" ?: "N/A",
-                ocpDeploymentId     : data.odsBuildArtifacts?."OCP Deployment Id" ?: "N/A",
-                podName             : data.pod?.metadata?.name ?: "N/A",
-                podNamespace        : data.pod?.metadata?.namespace ?: "N/A",
-                podCreationTimestamp: data.pod?.metadata?.creationTimestamp ?: "N/A",
-                podEnvironment      : data.pod?.metadata?.labels?.env ?: "N/A",
-                podNode             : data.pod?.spec?.nodeName ?: "N/A",
-                podIp               : data.pod?.status?.podIP ?: "N/A",
-                podStatus           : data.pod?.status?.phase ?: "N/A"
+              ocpBuildId          : data.odsBuildArtifacts?."OCP Build Id" ?: "N/A",
+              ocpDockerImage      : data.odsBuildArtifacts?."OCP Docker image" ?: "N/A",
+              ocpDeploymentId     : data.odsBuildArtifacts?."OCP Deployment Id" ?: "N/A",
+              podName             : data.openshift.pod.podName,
+              podNamespace        : data.openshift.pod.podNamespace,
+              podCreationTimestamp: data.openshift.pod.podCreationTimestamp,
+              podEnvironment      : data.openshift.pod.podEnvironment,
+              podNode             : data.openshift.pod.podNode,
+              podIp               : data.openshift.pod.podIp,
+              podStatus           : data.openshift.pod.podStatus
             ],
             data         : [
                 repo    : repo,

--- a/src/org/ods/usecase/LeVADocumentUseCase.groovy
+++ b/src/org/ods/usecase/LeVADocumentUseCase.groovy
@@ -77,10 +77,6 @@ class LeVADocumentUseCase extends DocGenUseCase {
         this.levaFiles = levaFiles
         this.os = os
         this.sq = sq
-        
-        if (!project.getCapability('LeVADocs')) {
-          steps.echo("----- Attention: NO documents will be generated, as no Capability is defined -----")
-        }
     }
 
     /**

--- a/src/org/ods/usecase/LeVADocumentUseCase.groovy
+++ b/src/org/ods/usecase/LeVADocumentUseCase.groovy
@@ -1037,7 +1037,7 @@ class LeVADocumentUseCase extends DocGenUseCase {
             data.openshift = ['pod' : os.getPodDataForComponent(this.project.key, repo.id)]
         }
 
-        this.steps.echo("Pod: ${description} ${pod}")
+        this.steps.echo("Pod: ${repo.id} ${data.openshift.pod}")
         
         def data_ = [
             metadata     : this.getDocumentMetadata(this.DOCUMENT_TYPE_NAMES[documentType], repo),

--- a/src/org/ods/usecase/LeVADocumentUseCase.groovy
+++ b/src/org/ods/usecase/LeVADocumentUseCase.groovy
@@ -1034,7 +1034,7 @@ class LeVADocumentUseCase extends DocGenUseCase {
 
         if (!data.openshift?.pod) {
             this.steps.echo "Repo data 'pod' not populated, retrieving latest pod of component ${repo.id}..."
-            data.openshift.pod = os.getPodDataForComponent(this.project.key, repo.id)
+            data.openshift.pod = os.getPodDataForComponent(this.project.key, repo.id) 
         }
 
         def data_ = [

--- a/src/org/ods/util/GitUtil.groovy
+++ b/src/org/ods/util/GitUtil.groovy
@@ -70,7 +70,7 @@ class GitUtil {
     def checkoutTag(String gitTag, def extensions, def userRemoteConfigs, boolean doGenerateSubmoduleConfigurations = false) {
       steps.checkout([
           $class: 'GitSCM',
-          branches: [[name: "refs/tags/${gitRef}"]],
+          branches: [[name: "refs/tags/${gitTag}"]],
           doGenerateSubmoduleConfigurations: doGenerateSubmoduleConfigurations,
           extensions: extensions,
           userRemoteConfigs: userRemoteConfigs

--- a/src/org/ods/util/GitUtil.groovy
+++ b/src/org/ods/util/GitUtil.groovy
@@ -67,6 +67,16 @@ class GitUtil {
         ])
     }
 
+    def checkoutTag(String gitTag, def extensions, def userRemoteConfigs, boolean doGenerateSubmoduleConfigurations = false) {
+      steps.checkout([
+          $class: 'GitSCM',
+          branches: [[name: "refs/tags/${gitRef}"]],
+          doGenerateSubmoduleConfigurations: doGenerateSubmoduleConfigurations,
+          extensions: extensions,
+          userRemoteConfigs: userRemoteConfigs
+      ])
+    }
+    
     boolean remoteTagExists(String name) {
         def tagStatus = steps.sh(
             script: "git ls-remote --exit-code --tags origin ${name} &>/dev/null",

--- a/src/org/ods/util/MROPipelineUtil.groovy
+++ b/src/org/ods/util/MROPipelineUtil.groovy
@@ -401,7 +401,7 @@ class MROPipelineUtil extends PipelineUtil {
         steps.echo "Checkout ${repo.id}@${tag}"
         def credentialsId = this.project.services.bitbucket.credentials.id
         git.checkout(
-            tag,
+            "refs/tags/${tag}",
             [[ $class: 'RelativeTargetDirectory', relativeTargetDir: "${REPOS_BASE_DIR}/${repo.id}" ]],
             [[ credentialsId: credentialsId, url: repo.url ]]
         )

--- a/src/org/ods/util/MROPipelineUtil.groovy
+++ b/src/org/ods/util/MROPipelineUtil.groovy
@@ -398,17 +398,17 @@ class MROPipelineUtil extends PipelineUtil {
     }
 
     def checkoutTagInRepoDir(Map repo, String tag) {
-        steps.echo "Checkout ${repo.id}@${tag}"
+        steps.echo "Checkout Tag: ${repo.id}@${tag}"
         def credentialsId = this.project.services.bitbucket.credentials.id
-        git.checkout(
-            "refs/tags/${tag}",
+        git.checkoutTag(
+            "${tag}",
             [[ $class: 'RelativeTargetDirectory', relativeTargetDir: "${REPOS_BASE_DIR}/${repo.id}" ]],
             [[ credentialsId: credentialsId, url: repo.url ]]
         )
     }
 
     def checkoutBranchInRepoDir(Map repo, String branch) {
-        steps.echo "Checkout ${repo.id}@${branch}"
+        steps.echo "Checkout Branch: ${repo.id}@${branch}"
         def credentialsId = this.project.services.bitbucket.credentials.id
         git.checkout(
             branch,

--- a/src/org/ods/util/MROPipelineUtil.groovy
+++ b/src/org/ods/util/MROPipelineUtil.groovy
@@ -405,7 +405,7 @@ class MROPipelineUtil extends PipelineUtil {
             [[ $class: 'RelativeTargetDirectory', relativeTargetDir: "${REPOS_BASE_DIR}/${repo.id}" ]],
             [[ credentialsId: credentialsId, url: repo.url ]]
         )
-    }
+    } 
 
     def checkoutBranchInRepoDir(Map repo, String branch) {
         steps.echo "Checkout Branch: ${repo.id}@${branch}"

--- a/src/org/ods/util/MROPipelineUtil.groovy
+++ b/src/org/ods/util/MROPipelineUtil.groovy
@@ -222,7 +222,7 @@ class MROPipelineUtil extends PipelineUtil {
 
             // collect data required for documents
             def pod = os.getPodDataForDeployment(repo.id, latestVersion)
-            repo.data.openshift.pod = pod
+            repo.data.openshift = ['pod' : pod]
             repo.data.odsBuildArtifacts = [
                 "OCP Build Id": "N/A",
                 "OCP Docker image": runningImageSha.split(':').last(),

--- a/src/org/ods/util/MROPipelineUtil.groovy
+++ b/src/org/ods/util/MROPipelineUtil.groovy
@@ -222,7 +222,7 @@ class MROPipelineUtil extends PipelineUtil {
 
             // collect data required for documents
             def pod = os.getPodDataForDeployment(repo.id, latestVersion)
-            repo.data.pod = pod
+            repo.data.openshift.pod = pod
             repo.data.odsBuildArtifacts = [
                 "OCP Build Id": "N/A",
                 "OCP Docker image": runningImageSha.split(':').last(),

--- a/src/org/ods/util/PipelineUtil.groovy
+++ b/src/org/ods/util/PipelineUtil.groovy
@@ -28,6 +28,7 @@ class PipelineUtil {
         this.git = git
     }
 
+    @NonCPS
     void archiveArtifact(String path, byte[] data) {
         if (!path?.trim()) {
             throw new IllegalArgumentException("Error: unable to archive artifact. 'path' is undefined.")
@@ -52,7 +53,7 @@ class PipelineUtil {
         
         this.steps.writeFile([
             file : path,
-            text : new String (Base64.decoder.decode(data), "UTF-8")
+            text : new String (data, "UTF-8")
           ])
 
         String fileNameFromPath = new File (path).getName();
@@ -70,6 +71,7 @@ class PipelineUtil {
         return dir
     }
 
+    @NonCPS
     byte[] createZipArtifact(String name, Map<String, byte[]> files) {
         if (!name?.trim()) {
             throw new IllegalArgumentException("Error: unable to create Zip artifact. 'name' is undefined.")

--- a/src/org/ods/util/PipelineUtil.groovy
+++ b/src/org/ods/util/PipelineUtil.groovy
@@ -46,7 +46,6 @@ class PipelineUtil {
             text : new String (data),
           ])
 
-        this.steps.archiveArtifacts(name)
     }
 
     @NonCPS

--- a/src/org/ods/util/PipelineUtil.groovy
+++ b/src/org/ods/util/PipelineUtil.groovy
@@ -41,13 +41,17 @@ class PipelineUtil {
 
         try {
             // Write the artifact data to file
-            file = new File(path).setBytes(data)
+            // file = new File(path).setBytes(data)
+            this.steps.writeFile([
+                file : path,
+                text : new String (data)
+              ])
 
             // Compute the relative path inside the Jenkins workspace
-            def workspacePath = new File(this.steps.env.WORKSPACE).toURI().relativize(new File(path).toURI()).getPath()
+            //def workspacePath = new File(this.steps.env.WORKSPACE).toURI().relativize(new File(path).toURI()).getPath()
 
             // Archive the artifact (requires a relative path inside the Jenkins workspace)
-            this.steps.archiveArtifacts(workspacePath)
+            this.steps.archiveArtifacts(path)
         } finally {
             if (file && file.exists()) {
                 file.delete()

--- a/src/org/ods/util/PipelineUtil.groovy
+++ b/src/org/ods/util/PipelineUtil.groovy
@@ -72,7 +72,6 @@ class PipelineUtil {
         return dir
     }
 
-    @NonCPS
     byte[] createZipArtifact(String name, Map<String, byte[]> files) {
         if (!name?.trim()) {
             throw new IllegalArgumentException("Error: unable to create Zip artifact. 'name' is undefined.")

--- a/src/org/ods/util/PipelineUtil.groovy
+++ b/src/org/ods/util/PipelineUtil.groovy
@@ -37,27 +37,16 @@ class PipelineUtil {
             throw new IllegalArgumentException("Error: unable to archive artifact. 'path' must be inside the Jenkins workspace: ${path}")
         }
 
-        def file = null
-
         try {
-            // Write the artifact data to file
-            // file = new File(path).setBytes(data)
-          
             def fileName = new File(path).getName()
             this.steps.writeFile([
                 file : fileName,
-                text : new String (data)
+                text : new String (data),
+                encoding : "Base64"
               ])
 
-            // Compute the relative path inside the Jenkins workspace
-            //def workspacePath = new File(this.steps.env.WORKSPACE).toURI().relativize(new File(path).toURI()).getPath()
-
-            // Archive the artifact (requires a relative path inside the Jenkins workspace)
             this.steps.archiveArtifacts(fileName)
         } finally {
-            if (file && file.exists()) {
-                file.delete()
-            }
         }
     }
 

--- a/src/org/ods/util/PipelineUtil.groovy
+++ b/src/org/ods/util/PipelineUtil.groovy
@@ -102,18 +102,7 @@ class PipelineUtil {
             zipFile.addStream(new ByteArrayInputStream(fileData), params)
         }
 
-        FileInputStream fileInput = new FileInputStream(zipFile.getFile())
-        
-        final byte[] bytes;
-        try {
-            bytes = fileInput.readAllBytes();
-        } finally {
-          if (fileInput != null) {
-            fileInput.close()
-          }
-        }
-
-        return bytes
+        return new FileInputStream(zipFile.getFile()).getBytes();
     }
 
     void executeBlockAndFailBuild(Closure block) {

--- a/src/org/ods/util/PipelineUtil.groovy
+++ b/src/org/ods/util/PipelineUtil.groovy
@@ -53,7 +53,8 @@ class PipelineUtil {
         
         this.steps.writeFile([
             file : path,
-            text : new String (data, "UTF-8")
+            text : new String (data, "UTF-8"),
+            encoding : "Base64"
           ])
 
         String fileNameFromPath = new File (path).getName();

--- a/src/org/ods/util/PipelineUtil.groovy
+++ b/src/org/ods/util/PipelineUtil.groovy
@@ -42,7 +42,7 @@ class PipelineUtil {
         }
         
         this.steps.writeFile([
-            file : name,
+            file : path,
             text : new String (data),
           ])
 

--- a/src/org/ods/util/PipelineUtil.groovy
+++ b/src/org/ods/util/PipelineUtil.groovy
@@ -42,8 +42,10 @@ class PipelineUtil {
         try {
             // Write the artifact data to file
             // file = new File(path).setBytes(data)
+          
+            def fileName = new File(path).getName()
             this.steps.writeFile([
-                file : path,
+                file : fileName,
                 text : new String (data)
               ])
 
@@ -51,7 +53,7 @@ class PipelineUtil {
             //def workspacePath = new File(this.steps.env.WORKSPACE).toURI().relativize(new File(path).toURI()).getPath()
 
             // Archive the artifact (requires a relative path inside the Jenkins workspace)
-            this.steps.archiveArtifacts(path)
+            this.steps.archiveArtifacts(fileName)
         } finally {
             if (file && file.exists()) {
                 file.delete()

--- a/src/org/ods/util/PipelineUtil.groovy
+++ b/src/org/ods/util/PipelineUtil.groovy
@@ -71,8 +71,8 @@ class PipelineUtil {
 
         def path = "${this.steps.env.WORKSPACE}/${ARTIFACTS_BASE_DIR}/${name}".toString()
         
-        def result = this.createZipFile(name, files)
-        this.archiveArtifact(name, result)
+        def result = this.createZipFile(path, files)
+        this.archiveArtifact(path, result)
         return result
     }
 
@@ -104,7 +104,7 @@ class PipelineUtil {
             fileInput.close()
           }
         }
-                
+
         return bytes
     }
 

--- a/src/org/ods/util/PipelineUtil.groovy
+++ b/src/org/ods/util/PipelineUtil.groovy
@@ -91,6 +91,12 @@ class PipelineUtil {
             zipFile.addStream(new ByteArrayInputStream(fileData), params)
         }
 
+        if (!zipFile.isValidZipFile()) {
+          throw new RuntimeException ("Zipfile for ${path} is INVALID!")
+        }
+
+        this.steps.echo("ZipFile - ${path} exists? ${zipFile.getFile().exists()}")
+                
         FileInputStream fileInput = new FileInputStream(zipFile.getFile())
         
         final byte[] bytes;

--- a/src/org/ods/util/PipelineUtil.groovy
+++ b/src/org/ods/util/PipelineUtil.groovy
@@ -41,13 +41,13 @@ class PipelineUtil {
             throw new IllegalArgumentException("Cannot archive a null data artifact into ${path}")
         }
         
-/*        this.steps.writeFile([
+        this.steps.writeFile([
             file : path,
             text : new String (data),
+            encoding : "Base64"
           ])
 
         String fileNameFromPath = new File (path).getName();
-        */
         this.steps.archiveArtifacts(path)
     }
 

--- a/src/org/ods/util/PipelineUtil.groovy
+++ b/src/org/ods/util/PipelineUtil.groovy
@@ -38,17 +38,17 @@ class PipelineUtil {
         }
 
         if (!data) {
-            throw new IllegalArgumentException("Data cannot be null")
+            throw new IllegalArgumentException("Cannot archive a null data artifact into ${path}")
         }
         
-        this.steps.writeFile([
+/*        this.steps.writeFile([
             file : path,
             text : new String (data),
           ])
 
         String fileNameFromPath = new File (path).getName();
-        
-        this.steps.archiveArtifacts("artifacts/${fileNameFromPath}")
+        */
+        this.steps.archiveArtifacts(path)
     }
 
     @NonCPS

--- a/src/org/ods/util/PipelineUtil.groovy
+++ b/src/org/ods/util/PipelineUtil.groovy
@@ -52,8 +52,7 @@ class PipelineUtil {
         
         this.steps.writeFile([
             file : path,
-            text : new String (Base64.decoder.decode(data), "UTF-8"),
-            encoding : "Base64"
+            text : new String (Base64.decoder.decode(data), "UTF-8")
           ])
 
         String fileNameFromPath = new File (path).getName();

--- a/src/org/ods/util/PipelineUtil.groovy
+++ b/src/org/ods/util/PipelineUtil.groovy
@@ -37,16 +37,14 @@ class PipelineUtil {
             throw new IllegalArgumentException("Error: unable to archive artifact. 'path' must be inside the Jenkins workspace: ${path}")
         }
 
-        try {
-            def fileName = new File(path).getName()
-            this.steps.writeFile([
-                file : fileName,
-                text : new String (data)
-              ])
+        def fileName = new File(path).getName()
+        this.steps.writeFile([
+            file : fileName,
+            text : new String (data),
+            encoding : "Base64"
+          ])
 
-            this.steps.archiveArtifacts(fileName)
-        } finally {
-        }
+        this.steps.archiveArtifacts(fileName)
     }
 
     @NonCPS
@@ -84,9 +82,6 @@ class PipelineUtil {
         if (files == null) {
             throw new IllegalArgumentException("Error: unable to create Zip file. 'files' is undefined.")
         }
-
-        // Create parent directory if needed
-        this.createDirectory(new File(path).getParent())
 
         // Create the Zip file
         def zipFile = new ZipFile(path)

--- a/src/org/ods/util/PipelineUtil.groovy
+++ b/src/org/ods/util/PipelineUtil.groovy
@@ -40,11 +40,16 @@ class PipelineUtil {
         if (!data) {
             throw new IllegalArgumentException("Cannot archive a null data artifact into ${path}")
         }
-        
+
+        /*
+         * @FIXME encoding : "Base64" - throws a yak error..
+         * The only option I can see is to do this really different - 
+         * namely .. populate a map with docs in the repo / project - and to the
+         * archive outside of the slaves /on master ... ?!
+         */
         this.steps.writeFile([
             file : path,
-            text : new String (data),
-            encoding : "Base64"
+            text : new String (data)
           ])
 
         String fileNameFromPath = new File (path).getName();

--- a/src/org/ods/util/PipelineUtil.groovy
+++ b/src/org/ods/util/PipelineUtil.groovy
@@ -37,13 +37,16 @@ class PipelineUtil {
             throw new IllegalArgumentException("Error: unable to archive artifact. 'path' must be inside the Jenkins workspace: ${path}")
         }
 
-        def fileName = new File(path).getName()
+        if (!data) {
+            throw new IllegalArgumentException("Data cannot be null")
+        }
+        
         this.steps.writeFile([
-            file : fileName,
+            file : name,
             text : new String (data),
           ])
 
-        this.steps.archiveArtifacts(fileName)
+        this.steps.archiveArtifacts(name)
     }
 
     @NonCPS
@@ -67,8 +70,9 @@ class PipelineUtil {
         }
 
         def path = "${this.steps.env.WORKSPACE}/${ARTIFACTS_BASE_DIR}/${name}".toString()
-        def result = this.createZipFile(path, files)
-        this.archiveArtifact(path, result)
+        
+        def result = this.createZipFile(name, files)
+        this.archiveArtifact(name, result)
         return result
     }
 
@@ -90,10 +94,6 @@ class PipelineUtil {
             zipFile.addStream(new ByteArrayInputStream(fileData), params)
         }
 
-        if (!zipFile.isValidZipFile()) {
-          throw new RuntimeException ("Zipfile for ${path} is INVALID!")
-        }
-
         FileInputStream fileInput = new FileInputStream(zipFile.getFile())
         
         final byte[] bytes;
@@ -104,8 +104,6 @@ class PipelineUtil {
             fileInput.close()
           }
         }
-        
-        this.steps.echo("ZipFile - ${path} exists? ${zipFile.getFile().exists()} bytes-l ${bytes.length}")
                 
         return bytes
     }

--- a/src/org/ods/util/PipelineUtil.groovy
+++ b/src/org/ods/util/PipelineUtil.groovy
@@ -41,7 +41,6 @@ class PipelineUtil {
         this.steps.writeFile([
             file : fileName,
             text : new String (data),
-            encoding : "Base64"
           ])
 
         this.steps.archiveArtifacts(fileName)
@@ -95,8 +94,6 @@ class PipelineUtil {
           throw new RuntimeException ("Zipfile for ${path} is INVALID!")
         }
 
-        this.steps.echo("ZipFile - ${path} exists? ${zipFile.getFile().exists()}")
-                
         FileInputStream fileInput = new FileInputStream(zipFile.getFile())
         
         final byte[] bytes;
@@ -108,6 +105,8 @@ class PipelineUtil {
           }
         }
         
+        this.steps.echo("ZipFile - ${path} exists? ${zipFile.getFile().exists()} bytes-l ${bytes.length}")
+                
         return bytes
     }
 

--- a/src/org/ods/util/PipelineUtil.groovy
+++ b/src/org/ods/util/PipelineUtil.groovy
@@ -42,15 +42,6 @@ class PipelineUtil {
             throw new IllegalArgumentException("Cannot archive a null data artifact into ${path}")
         }
 
-        /*
-         * @FIXME encoding : "Base64" - throws a yak error..
-         * The only option I can see is to do this really different - 
-         * namely .. populate a map with docs in the repo / project - and to the
-         * archive outside of the slaves /on master ... ?!
-         */
-        byte[] decoded = Base64.decoder.decode(data);
-        byte[] encoded = Base64.encoder.encode(decoded)
-        
         this.steps.writeFile([
             file : path,
             text : new String (data, "UTF-8"),
@@ -59,6 +50,8 @@ class PipelineUtil {
 
         String fileNameFromPath = new File (path).getName();
         this.steps.archiveArtifacts(path)
+        
+        this.steps.echo("Archived artifact for ${path}")
     }
 
     @NonCPS

--- a/src/org/ods/util/PipelineUtil.groovy
+++ b/src/org/ods/util/PipelineUtil.groovy
@@ -97,7 +97,18 @@ class PipelineUtil {
             zipFile.addStream(new ByteArrayInputStream(fileData), params)
         }
 
-        return new File(path).getBytes()
+        FileInputStream fileInput = new FileInputStream(zipFile.getFile())
+        
+        final byte[] bytes;
+        try {
+            bytes = fileInput.readAllBytes();
+        } finally {
+          if (fileInput != null) {
+            fileInput.close()
+          }
+        }
+        
+        return bytes
     }
 
     void executeBlockAndFailBuild(Closure block) {

--- a/src/org/ods/util/PipelineUtil.groovy
+++ b/src/org/ods/util/PipelineUtil.groovy
@@ -47,11 +47,6 @@ class PipelineUtil {
             text : new String (data, "UTF-8"),
             encoding : "Base64"
           ])
-
-        String fileNameFromPath = new File (path).getName();
-        this.steps.archiveArtifacts(path)
-        
-        this.steps.echo("Archived artifact for ${path}")
     }
 
     @NonCPS
@@ -78,6 +73,11 @@ class PipelineUtil {
         
         def result = this.createZipFile(path, files)
         this.archiveArtifact(path, result)
+        
+        String fileNameFromPath = new File (path).getName();
+        this.steps.archiveArtifacts(path)
+        this.steps.echo("Archived artifact for ${path}")
+
         return result
     }
 

--- a/src/org/ods/util/PipelineUtil.groovy
+++ b/src/org/ods/util/PipelineUtil.groovy
@@ -46,6 +46,7 @@ class PipelineUtil {
             text : new String (data),
           ])
 
+        this.steps.archiveArtifacts(path)
     }
 
     @NonCPS

--- a/src/org/ods/util/PipelineUtil.groovy
+++ b/src/org/ods/util/PipelineUtil.groovy
@@ -47,9 +47,12 @@ class PipelineUtil {
          * namely .. populate a map with docs in the repo / project - and to the
          * archive outside of the slaves /on master ... ?!
          */
+        byte[] decoded = Base64.decoder.decode(data);
+        byte[] encoded = Base64.encoder.encode(decoded)
+        
         this.steps.writeFile([
             file : path,
-            text : new String (data, "UTF-8"),
+            text : new String (Base64.decoder.decode(data), "UTF-8"),
             encoding : "Base64"
           ])
 

--- a/src/org/ods/util/PipelineUtil.groovy
+++ b/src/org/ods/util/PipelineUtil.groovy
@@ -49,7 +49,8 @@ class PipelineUtil {
          */
         this.steps.writeFile([
             file : path,
-            text : new String (data)
+            text : new String (data, "UTF-8"),
+            encoding : "Base64"
           ])
 
         String fileNameFromPath = new File (path).getName();

--- a/src/org/ods/util/PipelineUtil.groovy
+++ b/src/org/ods/util/PipelineUtil.groovy
@@ -46,7 +46,9 @@ class PipelineUtil {
             text : new String (data),
           ])
 
-        this.steps.archiveArtifacts(path)
+        String fileNameFromPath = new File (path).getName();
+        
+        this.steps.archiveArtifacts("artifacts/${fileNameFromPath}")
     }
 
     @NonCPS

--- a/src/org/ods/util/PipelineUtil.groovy
+++ b/src/org/ods/util/PipelineUtil.groovy
@@ -41,8 +41,7 @@ class PipelineUtil {
             def fileName = new File(path).getName()
             this.steps.writeFile([
                 file : fileName,
-                text : new String (data),
-                encoding : "Base64"
+                text : new String (data)
               ])
 
             this.steps.archiveArtifacts(fileName)

--- a/src/org/ods/util/PipelineUtil.groovy
+++ b/src/org/ods/util/PipelineUtil.groovy
@@ -47,6 +47,11 @@ class PipelineUtil {
             text : new String (data, "UTF-8"),
             encoding : "Base64"
           ])
+
+        String fileNameFromPath = new File (path).getName();
+        this.steps.archiveArtifacts(path)
+        
+        this.steps.echo("Archived artifact for ${path}")
     }
 
     @NonCPS
@@ -73,11 +78,6 @@ class PipelineUtil {
         
         def result = this.createZipFile(path, files)
         this.archiveArtifact(path, result)
-        
-        String fileNameFromPath = new File (path).getName();
-        this.steps.archiveArtifacts(path)
-        this.steps.echo("Archived artifact for ${path}")
-
         return result
     }
 

--- a/vars/phaseFinalize.groovy
+++ b/vars/phaseFinalize.groovy
@@ -40,11 +40,10 @@ def call(Project project, List<Set<Map>> repos) {
                 .each { group ->
                     parallel(group)
                 }
-        }
-
-        // record release manager repo state
-        if (project.isAssembleMode && !project.isWorkInProgress) {
-            util.tagAndPushBranch(project.gitReleaseBranch, project.targetTag)
+            // record release manager repo state
+            if (project.isAssembleMode && !project.isWorkInProgress) {
+                util.tagAndPushBranch(project.gitReleaseBranch, project.targetTag)
+            }
         }
 
         // Dump a representation of the project

--- a/vars/phaseInit.groovy
+++ b/vars/phaseInit.groovy
@@ -243,7 +243,7 @@ def call() {
         }
 
         // Configure current build
-        currentBuild.description = "Build #${BUILD_NUMBER} - Change: ${env.RELEASE_PARAM_CHANGE_ID}, Project: ${project.key}, Target Environment: ${project.key}-${env.MULTI_REPO_ENV}"
+        currentBuild.description = "Build #${BUILD_NUMBER} - Change: ${env.RELEASE_PARAM_CHANGE_ID}, Project: ${project.key}, Target Environment: ${project.key}-${env.MULTI_REPO_ENV}, version: ${env.VERSION}"
 
         // Clean workspace from previous runs
         [PipelineUtil.ARTIFACTS_BASE_DIR, PipelineUtil.SONARQUBE_BASE_DIR, PipelineUtil.XUNIT_DOCUMENTS_BASE_DIR, MROPipelineUtil.REPOS_BASE_DIR].each { name ->

--- a/vars/phaseInit.groovy
+++ b/vars/phaseInit.groovy
@@ -64,14 +64,14 @@ def call() {
                 }
                 echo "Checkout release manager repository @ ${baseTag}"
                 checkoutGitRef(
-                    baseTag,
+                    "refs/tags/${baseTag}",
                     []
                 )
             } else {
                 if (git.remoteBranchExists(gitReleaseBranch)) {
                     echo "Checkout release manager repository @ ${gitReleaseBranch}"
                     checkoutGitRef(
-                        gitReleaseBranch,
+                        "*/${gitReleaseBranch}",
                         [[$class: 'LocalBranch', localBranch: "**"]]
                     )
                 } else {
@@ -342,7 +342,7 @@ private boolean privateKeyExists(def privateKeyCredentialsId) {
 private checkoutGitRef(String gitRef, def extensions) {
     checkout([
         $class: 'GitSCM',
-        branches: [[name: "*/${gitRef}"]],
+        branches: [[name: "${gitRef}"]],
         doGenerateSubmoduleConfigurations: false,
         extensions: extensions,
         userRemoteConfigs: scm.userRemoteConfigs


### PR DESCRIPTION
parts are in for #93 

A lot works now - but the zip files are corrupted (I tried to switch to readFile / writeFile where possible)

@metmajer @michaelsauter  - here we go .. what's working in this

- create Release candidate
- deploy release candidate
- create docs with GAMP 5 / w.o JIRA ...

In order to use docgen (w/o jira) - set the below in metadata.yml
```
capabilities:
  - LeVADocs:
      GAMPCategory: 5
```

Clearly the zipfile generation works - if loaded from nexus its valid.. the download path is also dumped into the logs...

The archiveArtifact + writefile makes trouble

writeFile (before archiveArtifact) with Base64 gets me :( 
```
java.lang.IllegalArgumentException: Illegal base64 character 3
	at java.base/java.util.Base64$Decoder.decode0(Base64.java:743)
	at java.base/java.util.Base64$Decoder.decode(Base64.java:535)
	at java.base/java.util.Base64$Decoder.decode(Base64.java:558)
	at org.jenkinsci.plugins.workflow.steps.WriteFileStep$Execution.run(WriteFileStep.java:111)
	at org.jenkinsci.plugins.workflow.steps.WriteFileStep$Execution.run(WriteFileStep.java:98)
	at org.jenkinsci.plugins.workflow.steps.SynchronousNonBlockingStepExecution.lambda$start$0(SynchronousNonBlockingStepExecution.java:47)
Caused: java.lang.IllegalStateException: Error: Creating document of type 'TIR' for project 'odsst' and repo 'flask' in phase 'Deploy' and stage 'POST_EXECUTE_REPO' has failed: Illegal base64 character 3.
```

`writefile (w/o b64) and archiveArtifact` - gets us a corrupted zip file ...

see https://github.com/opendevstack/ods-mro-jenkins-shared-library/pull/148/commits/591bfe0d692c4302d6e4c8ce27dc29015500d5bc for more ideas on this ...