### PR TITLE
Fail message if executing in Q or P for WIP versions

### DIFF
--- a/src/org/ods/usecase/LeVADocumentUseCase.groovy
+++ b/src/org/ods/usecase/LeVADocumentUseCase.groovy
@@ -462,7 +462,7 @@ class LeVADocumentUseCase extends DocGenUseCase {
                         description       : testIssue.description ?: "N/A",
                         systemRequirement : testIssue.requirements.join(", "),
                         success           : testIssue.isSuccess ? "Y" : "N",
-                        remarks           : testIssue.isMissing ? "Not executed" : "N/A",
+                        remarks           : testIssue.isUnexecuted ? "Not executed" : "N/A",
                         softwareDesignSpec: (softwareDesignSpecs.join(", "))?: "N/A",
                         riskLevel         : riskLevels ? riskLevels.join(", ") : "N/A"
                     ]

--- a/vars/phaseInit.groovy
+++ b/vars/phaseInit.groovy
@@ -215,7 +215,12 @@ def call() {
         project.load(registry.get(GitUtil), registry.get(JiraUseCase))
         def repos = project.repositories
 
-        if (project.isPromotionMode && git.localTagExists(project.targetTag)) {
+         // Validate that for Q and P we have a valid version
+        if (project.isPromotionMode && ['Q', 'P'].contains(project.buildParams.targetEnvironmentToken) && buildParams.version == "WIP") {
+            throw new RuntimeException("Error: trying to deploy to Q or P without having defined a correct version. ${buildParams.version} version value is not allowed for those environments. If you are using Jira, please check that all values are set in the release manager issue")
+        }
+
+       if (project.isPromotionMode && git.localTagExists(project.targetTag)) {
             if (project.buildParams.targetEnvironmentToken == 'Q') {
                 steps.echo("WARNING: Deploying tag ${project.targetTag} again!")
             } else {

--- a/vars/phaseInit.groovy
+++ b/vars/phaseInit.groovy
@@ -217,7 +217,7 @@ def call() {
 
          // Validate that for Q and P we have a valid version
         if (project.isPromotionMode && ['Q', 'P'].contains(project.buildParams.targetEnvironmentToken) && buildParams.version == "WIP") {
-            throw new RuntimeException("Error: trying to deploy to Q or P without having defined a correct version. ${buildParams.version} version value is not allowed for those environments. If you are using Jira, please check that all values are set in the release manager issue")
+            throw new RuntimeException("Error: trying to deploy to Q or P without having defined a correct version. ${buildParams.version} version value is not allowed for those environments. If you are using Jira, please check that all values are set in the release manager issue. Build parameters obtained: ${buildParams}")
         }
 
        if (project.isPromotionMode && git.localTagExists(project.targetTag)) {


### PR DESCRIPTION
Add meaningful message and fail fast in this case. 

Also fix DTR comment message for missing tests. 