### PR TITLE
WIP: Add WIP watermark to TRC in case of failing tests

### DIFF
--- a/src/org/ods/scheduler/LeVADocumentScheduler.groovy
+++ b/src/org/ods/scheduler/LeVADocumentScheduler.groovy
@@ -96,9 +96,8 @@ class LeVADocumentScheduler extends DocGenScheduler {
             (LeVADocumentUseCase.DocumentType.RA as String): MROPipelineUtil.PipelinePhaseLifecycleStage.PRE_END,
             (LeVADocumentUseCase.DocumentType.IVP as String): MROPipelineUtil.PipelinePhaseLifecycleStage.POST_START,
             (LeVADocumentUseCase.DocumentType.IVR as String): MROPipelineUtil.PipelinePhaseLifecycleStage.PRE_END,
-
             (LeVADocumentUseCase.DocumentType.CFTP as String): MROPipelineUtil.PipelinePhaseLifecycleStage.POST_START,
-            (LeVADocumentUseCase.DocumentType.TRC as String): MROPipelineUtil.PipelinePhaseLifecycleStage.POST_START,
+            (LeVADocumentUseCase.DocumentType.TRC as String): MROPipelineUtil.PipelinePhaseLifecycleStage.PRE_END,
             (LeVADocumentUseCase.DocumentType.CFTR as String): MROPipelineUtil.PipelinePhaseLifecycleStage.PRE_END,
             (LeVADocumentUseCase.DocumentType.DIL as String): MROPipelineUtil.PipelinePhaseLifecycleStage.PRE_END,
             (LeVADocumentUseCase.DocumentType.TCP as String): MROPipelineUtil.PipelinePhaseLifecycleStage.POST_START,

--- a/src/org/ods/usecase/JiraUseCase.groovy
+++ b/src/org/ods/usecase/JiraUseCase.groovy
@@ -254,16 +254,19 @@ class JiraUseCase {
     void updateJiraReleaseStatusBuildNumber() {
         if (!this.jira) return
 
+        /*
         def releaseStatusIssueKey = this.project.buildParams.releaseStatusJiraIssueKey
         def releaseStatusIssueFields = this.project.getJiraFieldsForIssueType(JiraUseCase.IssueTypes.RELEASE_STATUS)
 
         def releaseStatusIssueBuildNumberField = releaseStatusIssueFields["Release Build"]
         this.jira.updateTextFieldsOnIssue(releaseStatusIssueKey, [(releaseStatusIssueBuildNumberField.id): "${this.project.buildParams.version}-${this.steps.env.BUILD_NUMBER}"])
+        */
     }
 
     void updateJiraReleaseStatusResult(String message, boolean isError) {
         if (!this.jira) return
 
+        /*
         def status = isError ? "Failed" : "Successful"
 
         def releaseStatusIssueKey = this.project.buildParams.releaseStatusJiraIssueKey
@@ -275,6 +278,7 @@ class JiraUseCase {
         if (message) {
             this.jira.appendCommentToIssue(releaseStatusIssueKey, "${message}\n\nSee: ${this.steps.env.RUN_DISPLAY_URL}")
         }
+        */
     }
 
     private void walkTestIssuesAndTestResults(List testIssues, Map testResults, Closure visitor) {

--- a/src/org/ods/usecase/JiraUseCase.groovy
+++ b/src/org/ods/usecase/JiraUseCase.groovy
@@ -254,19 +254,16 @@ class JiraUseCase {
     void updateJiraReleaseStatusBuildNumber() {
         if (!this.jira) return
 
-        /*
         def releaseStatusIssueKey = this.project.buildParams.releaseStatusJiraIssueKey
         def releaseStatusIssueFields = this.project.getJiraFieldsForIssueType(JiraUseCase.IssueTypes.RELEASE_STATUS)
 
         def releaseStatusIssueBuildNumberField = releaseStatusIssueFields["Release Build"]
         this.jira.updateTextFieldsOnIssue(releaseStatusIssueKey, [(releaseStatusIssueBuildNumberField.id): "${this.project.buildParams.version}-${this.steps.env.BUILD_NUMBER}"])
-        */
     }
 
     void updateJiraReleaseStatusResult(String message, boolean isError) {
         if (!this.jira) return
 
-        /*
         def status = isError ? "Failed" : "Successful"
 
         def releaseStatusIssueKey = this.project.buildParams.releaseStatusJiraIssueKey
@@ -278,7 +275,6 @@ class JiraUseCase {
         if (message) {
             this.jira.appendCommentToIssue(releaseStatusIssueKey, "${message}\n\nSee: ${this.steps.env.RUN_DISPLAY_URL}")
         }
-        */
     }
 
     private void walkTestIssuesAndTestResults(List testIssues, Map testResults, Closure visitor) {

--- a/src/org/ods/usecase/LeVADocumentUseCase.groovy
+++ b/src/org/ods/usecase/LeVADocumentUseCase.groovy
@@ -1,11 +1,13 @@
 package org.ods.usecase
 
+import groovy.json.JsonOutput
+
+import java.time.LocalDateTime
+
 import org.apache.commons.io.FilenameUtils
 import org.ods.scheduler.LeVADocumentScheduler
 import org.ods.service.*
 import org.ods.util.*
-
-import java.time.LocalDateTime
 
 class LeVADocumentUseCase extends DocGenUseCase {
 
@@ -1138,8 +1140,12 @@ class LeVADocumentUseCase extends DocGenUseCase {
         return this.createDocument(getDocumentTemplateName(documentType), repo, data_, [:], modifier, documentType, watermarkText)
     }
 
-    String createTRC(Map repo = null, Map data = null) {
+    String createTRC(Map repo, Map data) {
         def documentType = DocumentType.TRC as String
+
+        def acceptanceTestData = data.tests.acceptance
+        def installationTestData = data.tests.installation
+        def integrationTestData = data.tests.integration
 
         def sections = this.jiraUseCase.getDocumentChapterData(documentType)
         if (!sections) {
@@ -1151,9 +1157,23 @@ class LeVADocumentUseCase extends DocGenUseCase {
         def sectionsNotDone = this.getSectionsNotDone(sections)
         this.project.data.jira.undone.docChapters[documentType] = sectionsNotDone
 
-        def watermarkText = this.getWatermarkText(documentType, this.project.hasWipJiraIssues())
+        def systemRequirements = this.project.getSystemRequirements()
 
-        def systemRequirements = this.project.getSystemRequirements().collect { r ->
+        // Compute the test issues we do not consider done (not successful)
+        def testIssues = systemRequirements.collect { it.getResolvedTests() }.flatten().unique()
+        this.steps.echo("??? testIssues: ${JsonOutput.toJson(testIssues)}")
+
+        this.computeTestDiscrepancies(null, testIssues, junit.combineTestResults([acceptanceTestData.testResults, installationTestData.testResults, integrationTestData.testResults]))
+        def testIssuesWip = testIssues.findAll { !it.status.equalsIgnoreCase("cancelled") && (!it.isSuccess || it.isUnexecuted) }
+        this.steps.echo("??? testIssuesWip: ${JsonOutput.toJson(testIssuesWip)}")
+
+        def hasFailingTestIssues = !testIssuesWip.isEmpty()
+        this.steps.echo("??? hasFailingTestIssues: ${hasFailingTestIssues}")
+
+        def watermarkText = this.getWatermarkText(documentType, hasFailingTestIssues || this.project.hasWipJiraIssues())
+        this.steps.echo("??? watermarkText: ${watermarkText}")
+
+        systemRequirements = systemRequirements.collect { r ->
             [
                 key        : r.key,
                 name       : r.name,
@@ -1174,7 +1194,7 @@ class LeVADocumentUseCase extends DocGenUseCase {
         ]
 
         def uri = this.createDocument(getDocumentTemplateName(documentType), null, data_, [:], null, documentType, watermarkText)
-        this.updateJiraDocumentationTrackingIssue(documentType, "A new ${DOCUMENT_TYPE_NAMES[documentType]} has been generated and is available at: ${uri}.", sectionsNotDone)
+        this.updateJiraDocumentationTrackingIssue(documentType, "A new ${DOCUMENT_TYPE_NAMES[documentType]} has been generated and is available at: ${uri}.", sectionsNotDone + testIssuesWip)
         return uri
     }
 

--- a/src/org/ods/usecase/LeVADocumentUseCase.groovy
+++ b/src/org/ods/usecase/LeVADocumentUseCase.groovy
@@ -1164,13 +1164,15 @@ class LeVADocumentUseCase extends DocGenUseCase {
         this.steps.echo("??? testIssues: ${JsonOutput.toJson(testIssues)}")
 
         this.computeTestDiscrepancies(null, testIssues, junit.combineTestResults([acceptanceTestData.testResults, installationTestData.testResults, integrationTestData.testResults]))
+        this.steps.echo("??? testIssues (after combination) ${JsonOutput.toJson(testIssues)}")
+
         def testIssuesWip = testIssues.findAll { !it.status.equalsIgnoreCase("cancelled") && (!it.isSuccess || it.isUnexecuted) }
         this.steps.echo("??? testIssuesWip: ${JsonOutput.toJson(testIssuesWip)}")
 
-        def hasFailingTestIssues = !testIssuesWip.isEmpty()
-        this.steps.echo("??? hasFailingTestIssues: ${hasFailingTestIssues}")
+        def hasWipTestIssues = !testIssuesWip.isEmpty()
+        this.steps.echo("??? hasWipTestIssues: ${hasWipTestIssues}")
 
-        def watermarkText = this.getWatermarkText(documentType, hasFailingTestIssues || this.project.hasWipJiraIssues())
+        def watermarkText = this.getWatermarkText(documentType, hasWipTestIssues || this.project.hasWipJiraIssues())
         this.steps.echo("??? watermarkText: ${watermarkText}")
 
         systemRequirements = systemRequirements.collect { r ->

--- a/src/org/ods/usecase/LeVADocumentUseCase.groovy
+++ b/src/org/ods/usecase/LeVADocumentUseCase.groovy
@@ -1165,7 +1165,6 @@ class LeVADocumentUseCase extends DocGenUseCase {
         }
 
         this.computeTestDiscrepancies(null, testIssues, junit.combineTestResults([acceptanceTestData.testResults, installationTestData.testResults, integrationTestData.testResults]))
-        this.steps.echo("??? testIssues (after combination) ${JsonOutput.toJson(testIssues)}")
 
         def testIssuesWip = testIssues.findAll { !it.status.equalsIgnoreCase("cancelled") && (!it.isSuccess || it.isUnexecuted) }
 

--- a/src/org/ods/util/Project.groovy
+++ b/src/org/ods/util/Project.groovy
@@ -316,7 +316,7 @@ class Project {
         JiraDataItem.TYPES_WITH_STATUS.each { type ->
             if (data.containsKey(type)) {
                 result[type] = data[type].findAll { key, issue ->
-                    issue.status != null && issue.status.toLowerCase() != "done" && issue.status.toLowerCase() != "cancelled"
+                    issue.status != null && !issue.status.equalsIgnoreCase("done") && !issue.status.equalsIgnoreCase("cancelled")
                 }
                 .collect { key, issue ->
                     return key
@@ -785,6 +785,7 @@ class Project {
 
         // FIXME: fix data types that should be sent correctly by the REST endpoint
         result.project.id = result.project.id as String
+
         result.tests.each { key, test ->
             test.id = test.id as String
             test.bugs = test.bugs ?: []

--- a/test/groovy/org/ods/scheduler/LeVADocumentSchedulerSpec.groovy
+++ b/test/groovy/org/ods/scheduler/LeVADocumentSchedulerSpec.groovy
@@ -1882,10 +1882,10 @@ class LeVADocumentSchedulerSpec extends SpecHelper {
         LeVADocumentUseCase.DocumentType.TRC | null | MROPipelineUtil.PipelinePhases.DEPLOY   | MROPipelineUtil.PipelinePhaseLifecycleStage.PRE_EXECUTE_REPO  || false
         LeVADocumentUseCase.DocumentType.TRC | null | MROPipelineUtil.PipelinePhases.DEPLOY   | MROPipelineUtil.PipelinePhaseLifecycleStage.POST_EXECUTE_REPO || false
         LeVADocumentUseCase.DocumentType.TRC | null | MROPipelineUtil.PipelinePhases.DEPLOY   | MROPipelineUtil.PipelinePhaseLifecycleStage.PRE_END           || false
-        LeVADocumentUseCase.DocumentType.TRC | null | MROPipelineUtil.PipelinePhases.TEST     | MROPipelineUtil.PipelinePhaseLifecycleStage.POST_START        || true
+        LeVADocumentUseCase.DocumentType.TRC | null | MROPipelineUtil.PipelinePhases.TEST     | MROPipelineUtil.PipelinePhaseLifecycleStage.POST_START        || false
         LeVADocumentUseCase.DocumentType.TRC | null | MROPipelineUtil.PipelinePhases.TEST     | MROPipelineUtil.PipelinePhaseLifecycleStage.PRE_EXECUTE_REPO  || false
         LeVADocumentUseCase.DocumentType.TRC | null | MROPipelineUtil.PipelinePhases.TEST     | MROPipelineUtil.PipelinePhaseLifecycleStage.POST_EXECUTE_REPO || false
-        LeVADocumentUseCase.DocumentType.TRC | null | MROPipelineUtil.PipelinePhases.TEST     | MROPipelineUtil.PipelinePhaseLifecycleStage.PRE_END           || false
+        LeVADocumentUseCase.DocumentType.TRC | null | MROPipelineUtil.PipelinePhases.TEST     | MROPipelineUtil.PipelinePhaseLifecycleStage.PRE_END           || true
         LeVADocumentUseCase.DocumentType.TRC | null | MROPipelineUtil.PipelinePhases.RELEASE  | MROPipelineUtil.PipelinePhaseLifecycleStage.POST_START        || false
         LeVADocumentUseCase.DocumentType.TRC | null | MROPipelineUtil.PipelinePhases.RELEASE  | MROPipelineUtil.PipelinePhaseLifecycleStage.PRE_EXECUTE_REPO  || false
         LeVADocumentUseCase.DocumentType.TRC | null | MROPipelineUtil.PipelinePhases.RELEASE  | MROPipelineUtil.PipelinePhaseLifecycleStage.POST_EXECUTE_REPO || false
@@ -3284,10 +3284,10 @@ class LeVADocumentSchedulerSpec extends SpecHelper {
         LeVADocumentUseCase.DocumentType.TRC | null | MROPipelineUtil.PipelinePhases.DEPLOY   | MROPipelineUtil.PipelinePhaseLifecycleStage.PRE_EXECUTE_REPO  || false
         LeVADocumentUseCase.DocumentType.TRC | null | MROPipelineUtil.PipelinePhases.DEPLOY   | MROPipelineUtil.PipelinePhaseLifecycleStage.POST_EXECUTE_REPO || false
         LeVADocumentUseCase.DocumentType.TRC | null | MROPipelineUtil.PipelinePhases.DEPLOY   | MROPipelineUtil.PipelinePhaseLifecycleStage.PRE_END           || false
-        LeVADocumentUseCase.DocumentType.TRC | null | MROPipelineUtil.PipelinePhases.TEST     | MROPipelineUtil.PipelinePhaseLifecycleStage.POST_START        || true
+        LeVADocumentUseCase.DocumentType.TRC | null | MROPipelineUtil.PipelinePhases.TEST     | MROPipelineUtil.PipelinePhaseLifecycleStage.POST_START        || false
         LeVADocumentUseCase.DocumentType.TRC | null | MROPipelineUtil.PipelinePhases.TEST     | MROPipelineUtil.PipelinePhaseLifecycleStage.PRE_EXECUTE_REPO  || false
         LeVADocumentUseCase.DocumentType.TRC | null | MROPipelineUtil.PipelinePhases.TEST     | MROPipelineUtil.PipelinePhaseLifecycleStage.POST_EXECUTE_REPO || false
-        LeVADocumentUseCase.DocumentType.TRC | null | MROPipelineUtil.PipelinePhases.TEST     | MROPipelineUtil.PipelinePhaseLifecycleStage.PRE_END           || false
+        LeVADocumentUseCase.DocumentType.TRC | null | MROPipelineUtil.PipelinePhases.TEST     | MROPipelineUtil.PipelinePhaseLifecycleStage.PRE_END           || true
         LeVADocumentUseCase.DocumentType.TRC | null | MROPipelineUtil.PipelinePhases.RELEASE  | MROPipelineUtil.PipelinePhaseLifecycleStage.POST_START        || false
         LeVADocumentUseCase.DocumentType.TRC | null | MROPipelineUtil.PipelinePhases.RELEASE  | MROPipelineUtil.PipelinePhaseLifecycleStage.PRE_EXECUTE_REPO  || false
         LeVADocumentUseCase.DocumentType.TRC | null | MROPipelineUtil.PipelinePhases.RELEASE  | MROPipelineUtil.PipelinePhaseLifecycleStage.POST_EXECUTE_REPO || false
@@ -4686,10 +4686,10 @@ class LeVADocumentSchedulerSpec extends SpecHelper {
         LeVADocumentUseCase.DocumentType.TRC | null | MROPipelineUtil.PipelinePhases.DEPLOY   | MROPipelineUtil.PipelinePhaseLifecycleStage.PRE_EXECUTE_REPO  || false
         LeVADocumentUseCase.DocumentType.TRC | null | MROPipelineUtil.PipelinePhases.DEPLOY   | MROPipelineUtil.PipelinePhaseLifecycleStage.POST_EXECUTE_REPO || false
         LeVADocumentUseCase.DocumentType.TRC | null | MROPipelineUtil.PipelinePhases.DEPLOY   | MROPipelineUtil.PipelinePhaseLifecycleStage.PRE_END           || false
-        LeVADocumentUseCase.DocumentType.TRC | null | MROPipelineUtil.PipelinePhases.TEST     | MROPipelineUtil.PipelinePhaseLifecycleStage.POST_START        || true
+        LeVADocumentUseCase.DocumentType.TRC | null | MROPipelineUtil.PipelinePhases.TEST     | MROPipelineUtil.PipelinePhaseLifecycleStage.POST_START        || false
         LeVADocumentUseCase.DocumentType.TRC | null | MROPipelineUtil.PipelinePhases.TEST     | MROPipelineUtil.PipelinePhaseLifecycleStage.PRE_EXECUTE_REPO  || false
         LeVADocumentUseCase.DocumentType.TRC | null | MROPipelineUtil.PipelinePhases.TEST     | MROPipelineUtil.PipelinePhaseLifecycleStage.POST_EXECUTE_REPO || false
-        LeVADocumentUseCase.DocumentType.TRC | null | MROPipelineUtil.PipelinePhases.TEST     | MROPipelineUtil.PipelinePhaseLifecycleStage.PRE_END           || false
+        LeVADocumentUseCase.DocumentType.TRC | null | MROPipelineUtil.PipelinePhases.TEST     | MROPipelineUtil.PipelinePhaseLifecycleStage.PRE_END           || true
         LeVADocumentUseCase.DocumentType.TRC | null | MROPipelineUtil.PipelinePhases.RELEASE  | MROPipelineUtil.PipelinePhaseLifecycleStage.POST_START        || false
         LeVADocumentUseCase.DocumentType.TRC | null | MROPipelineUtil.PipelinePhases.RELEASE  | MROPipelineUtil.PipelinePhaseLifecycleStage.PRE_EXECUTE_REPO  || false
         LeVADocumentUseCase.DocumentType.TRC | null | MROPipelineUtil.PipelinePhases.RELEASE  | MROPipelineUtil.PipelinePhaseLifecycleStage.POST_EXECUTE_REPO || false
@@ -5977,7 +5977,6 @@ class LeVADocumentSchedulerSpec extends SpecHelper {
         scheduler.run(MROPipelineUtil.PipelinePhases.TEST, MROPipelineUtil.PipelinePhaseLifecycleStage.POST_START)
 
         then:
-        1 * usecase.invokeMethod("createTRC", [null, null] as Object[])
         1 * usecase.invokeMethod("createTCP", [null, null] as Object[])
         1 * usecase.invokeMethod("createIVP", [null, null] as Object[])
         1 * usecase.invokeMethod("createCFTP", [null, null] as Object[])
@@ -5993,6 +5992,7 @@ class LeVADocumentSchedulerSpec extends SpecHelper {
         1 * usecase.invokeMethod("createDIL", [[:], data] as Object[])
         1 * usecase.invokeMethod("createCFTR", [[:], data] as Object[])
         1 * usecase.invokeMethod("createSSDS", [[:], data] as Object[])
+        1 * usecase.invokeMethod("createTRC", [[:], data] as Object[])
         0 * usecase.invokeMethod(*_)
     }
 
@@ -6197,7 +6197,6 @@ class LeVADocumentSchedulerSpec extends SpecHelper {
 
         then:
         1 * usecase.invokeMethod("createCFTP", [null, null] as Object[])
-        1 * usecase.invokeMethod("createTRC", [null, null] as Object[])
         1 * usecase.invokeMethod("createIVP", [null, null] as Object[])
         1 * usecase.invokeMethod("createTCP", [null, null] as Object[])
         0 * usecase.invokeMethod(*_)
@@ -6212,6 +6211,7 @@ class LeVADocumentSchedulerSpec extends SpecHelper {
         1 * usecase.invokeMethod("createDIL", [[:], data] as Object[])
         1 * usecase.invokeMethod("createSSDS", [[:], data] as Object[])
         1 * usecase.invokeMethod("createTCR", [[:], data] as Object[])
+        1 * usecase.invokeMethod("createTRC", [[:], data] as Object[])
         0 * usecase.invokeMethod(*_)
     }
 
@@ -6455,7 +6455,6 @@ class LeVADocumentSchedulerSpec extends SpecHelper {
         scheduler.run(MROPipelineUtil.PipelinePhases.TEST, MROPipelineUtil.PipelinePhaseLifecycleStage.POST_START)
 
         then:
-        1 * usecase.invokeMethod("createTRC", [null, null] as Object[])
         1 * usecase.invokeMethod("createCFTP", [null, null] as Object[])
         1 * usecase.invokeMethod("createIVP", [null, null] as Object[])
         1 * usecase.invokeMethod("createTCP", [null, null] as Object[])
@@ -6471,18 +6470,7 @@ class LeVADocumentSchedulerSpec extends SpecHelper {
         1 * usecase.invokeMethod("createIVR", [[:], data] as Object[])
         1 * usecase.invokeMethod("createSSDS", [[:], data] as Object[])
         1 * usecase.invokeMethod("createTCR", [[:], data] as Object[])
-        0 * usecase.invokeMethod(*_)
-
-        when:
-        scheduler.run(MROPipelineUtil.PipelinePhases.TEST, MROPipelineUtil.PipelinePhaseLifecycleStage.PRE_END, [:], data)
-
-        then:
-        1 * usecase.invokeMethod("createDIL", [[:], data] as Object[])
-        1 * usecase.invokeMethod("createRA", [[:], data] as Object[])
-        1 * usecase.invokeMethod("createCFTR", [[:], data] as Object[])
-        1 * usecase.invokeMethod("createIVR", [[:], data] as Object[])
-        1 * usecase.invokeMethod("createSSDS", [[:], data] as Object[])
-        1 * usecase.invokeMethod("createTCR", [[:], data] as Object[])
+        1 * usecase.invokeMethod("createTRC", [[:], data] as Object[])
         0 * usecase.invokeMethod(*_)
 
         when:
@@ -6616,7 +6604,6 @@ class LeVADocumentSchedulerSpec extends SpecHelper {
         scheduler.run(MROPipelineUtil.PipelinePhases.TEST, MROPipelineUtil.PipelinePhaseLifecycleStage.POST_START)
 
         then:
-        1 * usecase.invokeMethod("createTRC", [null, null] as Object[])
         0 * usecase.invokeMethod(*_)
 
         when:
@@ -6627,6 +6614,7 @@ class LeVADocumentSchedulerSpec extends SpecHelper {
         1 * usecase.invokeMethod("createDIL", [[:], data] as Object[])
         1 * usecase.invokeMethod("createTCR", [[:], data] as Object[])
         1 * usecase.invokeMethod("createCFTR", [[:], data] as Object[])
+        1 * usecase.invokeMethod("createTRC", [[:], data] as Object[])
         0 * usecase.invokeMethod(*_)
     }
 
@@ -6675,7 +6663,6 @@ class LeVADocumentSchedulerSpec extends SpecHelper {
         scheduler.run(MROPipelineUtil.PipelinePhases.TEST, MROPipelineUtil.PipelinePhaseLifecycleStage.POST_START)
 
         then:
-        1 * usecase.invokeMethod("createTRC", [null, null] as Object[])
         0 * usecase.invokeMethod(*_)
 
         when:
@@ -6686,6 +6673,7 @@ class LeVADocumentSchedulerSpec extends SpecHelper {
         1 * usecase.invokeMethod("createDIL", [[:], data] as Object[])
         1 * usecase.invokeMethod("createCFTR", [[:], data] as Object[])
         1 * usecase.invokeMethod("createTCR", [[:], data] as Object[])
+        1 * usecase.invokeMethod("createTRC", [[:], data] as Object[])
         0 * usecase.invokeMethod(*_)
     }
 
@@ -6754,7 +6742,6 @@ class LeVADocumentSchedulerSpec extends SpecHelper {
         scheduler.run(MROPipelineUtil.PipelinePhases.TEST, MROPipelineUtil.PipelinePhaseLifecycleStage.POST_START)
 
         then:
-        1 * usecase.invokeMethod("createTRC", [null, null] as Object[])
         0 * usecase.invokeMethod(*_)
 
         when:
@@ -6765,6 +6752,7 @@ class LeVADocumentSchedulerSpec extends SpecHelper {
         1 * usecase.invokeMethod("createDIL", [[:], data] as Object[])
         1 * usecase.invokeMethod("createCFTR", [[:], data] as Object[])
         1 * usecase.invokeMethod("createTCR", [[:], data] as Object[])
+        1 * usecase.invokeMethod("createTRC", [[:], data] as Object[])
         0 * usecase.invokeMethod(*_)
     }
 


### PR DESCRIPTION
This PR adds the WIP watermark to the TRC document in cases it contains failing tests. The document still contains all tests (successful and failing). The WIP watermark indicates though that it's not final. Additionally, in Project.groovy, we filter out all test issues with status "cancelled".