### PR TITLE
Encode userinfo part

### DIFF
--- a/vars/runOnAgentPod.groovy
+++ b/vars/runOnAgentPod.groovy
@@ -16,7 +16,7 @@ def call(Project project, boolean condition, Closure block) {
             git.configureUser()
             unstash("wholeWorkspace")
             withCredentials([usernamePassword(credentialsId: project.services.bitbucket.credentials.id, usernameVariable: 'BITBUCKET_USER', passwordVariable: 'BITBUCKET_PW')]) {
-                def urlWithCredentials = "https://${BITBUCKET_USER}:${BITBUCKET_PW}@${bitbucketHost}"
+                def urlWithCredentials = "https://${java.net.URLEncoder.encode(env.BITBUCKET_USER, "UTF-8")}:${java.net.URLEncoder.encode(env.BITBUCKET_PW, "UTF-8")}@${bitbucketHost}"
                 writeFile(file: "${env.HOME}/.git-credentials", text: urlWithCredentials)
                 sh(script: "git config --global credential.helper store", label : "setup credential helper")
             }


### PR DESCRIPTION
:(

Otherwise special characters might prevent username / password to be read correctly (e.g. `:` or `@` symbols ...).

http://www.faqs.org/rfcs/rfc3986.html defines the userinfo part to be percent encoded in section 3.2.1:
```
userinfo    = *( unreserved / pct-encoded / sub-delims / ":" )
```

For `master` (which is in ods-jenkins-shared-library) I'll check if there are more places where we should apply this.

As a workaround for affected users, one can place the contents of https://gist.github.com/michaelsauter/16bd497a2052b014f31fb40da8ad33d7 (which includes the suggested patch here) just before the call of `mroPipeline` to override the global `runOnAgentPod`.